### PR TITLE
Add support for plots definition in a python script

### DIFF
--- a/plotUtils/Makefile
+++ b/plotUtils/Makefile
@@ -3,10 +3,10 @@ SrcSuf        = cpp
 
 
 CXX           = g++
-CXXFLAGS      = $(shell root-config --cflags) -Iexternal/include
+CXXFLAGS      = $(shell root-config --cflags) $(shell python-config --includes) -Iexternal/include
 LD			  = g++
-LIBS          = $(shell root-config --libs) -lTreePlayer
-LDFLAGS		  = $(shell root-config --ldflags)
+LIBS          = $(shell root-config --libs) $(shell python-config --libs) -lTreePlayer
+LDFLAGS		  = $(shell root-config --ldflags) -L$(shell python-config --prefix)/lib
 
 #------------------------------------------------------------------------------
 SOURCESHIST	= createHistoWithMultiDraw.cpp external/src/jsoncpp.cpp external/src/TMultiDrawTreePlayer_dict.cpp external/src/TMultiDrawTreePlayer.cpp

--- a/plotUtils/createHistoWithMultiDraw.cpp
+++ b/plotUtils/createHistoWithMultiDraw.cpp
@@ -1,11 +1,14 @@
 // Read some trees, output an histos
 // A. Mertens (September 2015)
 
+#include <Python.h>
+
 #include <json/json.h>
 
 #include <iostream>
 #include <fstream>
 #include <memory>
+#include <cstdio>
 
 #include <TVirtualTreePlayer.h>
 #include <TMultiDrawTreePlayer.h>
@@ -23,22 +26,108 @@ struct Plot {
     std::string binning;
 };
 
-bool execute(const std::string& datasets_json, const std::vector<std::string>& plots_json) {
-    // Setting the TVirtualTreePlayer
-    TVirtualTreePlayer::SetPlayer("TMultiDrawTreePlayer");
+#define CHECK_AND_GET(var, obj) if (PyDict_Contains(value, obj) == 1) { \
+    PyObject* item = PyDict_GetItem(value, obj); \
+    if (! PyString_Check(item)) {\
+        std::cerr << "Error: the '" << PyString_AsString(obj) << "' value must be a string" << std::endl; \
+        return false; \
+    } \
+    var = PyString_AsString(item); \
+} else { \
+    std::cerr << "Error: '" << PyString_AsString(obj) << "' key is missing" << std::endl; \
+    return false; \
+}
 
-    // Getting the list of samples    
-    Json::Value samplesroot;
-    {
-        std::ifstream config_doc(datasets_json);
+bool plot_from_PyObject(PyObject* key, PyObject* value, Plot& plot) {
+    static PyObject* PY_VARIABLE = PyString_FromString("variable");
+    static PyObject* PY_PLOT_CUT = PyString_FromString("plot_cut");
+    static PyObject* PY_BINNING = PyString_FromString("binning");
 
-        Json::Reader samplesreader;
-        bool parsingSuccessful = samplesreader.parse(config_doc, samplesroot, false);
-        if (!parsingSuccessful) {
-            std::cerr << "Failed to parse '" << datasets_json << "'" << std::endl;
+    if (! PyString_Check(key)) {
+        std::cerr << "Error: plots dictionnary key must be a string" << std::endl;
+        return false;
+    }
+
+    if (! PyDict_Check(value)) {
+        std::cerr << "Error: plots dictionnary value must be a dictionnary" << std::endl;
+    }
+
+    plot.name = PyString_AsString(key);
+    CHECK_AND_GET(plot.variable, PY_VARIABLE);
+    CHECK_AND_GET(plot.plot_cut, PY_PLOT_CUT);
+    CHECK_AND_GET(plot.binning, PY_BINNING);
+
+    return true;
+}
+
+bool execute(const std::string& datasets_json, const std::vector<Plot>& plots);
+
+bool execute(const std::string& datasets_json, const std::string& python) {
+    std::FILE* f = std::fopen(python.c_str(), "r");
+    if (!f) {
+        std::cerr << "Failed to open '" << python << "'" <<std::endl;
+        return false;
+    }
+
+    std::vector<Plot> plots;
+
+    Py_Initialize();
+
+    const std::string PLOTS_KEY_NAME = "plots";
+
+    // Get a reference to the main module
+    // and global dictionary
+    PyObject* main_module = PyImport_AddModule("__main__");
+    PyObject* global_dict = PyModule_GetDict(main_module);
+
+    // Execute the script
+    PyObject* script_result = PyRun_File(f, python.c_str(), Py_file_input, global_dict, global_dict);
+
+    if (! script_result) {
+        PyErr_Print();
+        return false;
+    } else {
+        PyObject* py_plots = PyDict_GetItemString(global_dict, "plots");
+        if (!py_plots) {
+            std::cerr << "No 'plots' variable declared in python script" << std::endl;
             return false;
         }
+
+        if (! PyDict_Check(py_plots)) {
+            std::cerr << "The 'plots' variable is not a dictionnary" << std::endl;
+            return false;
+        }
+
+        size_t l = PyDict_Size(py_plots);
+        if (! l)
+            return true;
+
+        PyObject* keys = PyDict_Keys(py_plots);
+        PyObject* values = PyDict_Values(py_plots);
+
+        for (size_t i = 0; i < PyList_Size(keys); i++) {
+            PyObject* key = PyList_GetItem(keys, i);
+            PyObject* value = PyList_GetItem(values, i);
+
+            Plot plot;
+            if (plot_from_PyObject(key, value, plot)) {
+                plots.push_back(plot); 
+            }
+        }
     }
+
+    Py_Finalize();
+
+    if (plots.empty())
+        return false;
+
+    return execute(datasets_json, plots);
+}
+
+// Plots are specified in JSON files
+bool execute(const std::string& datasets_json, const std::vector<std::string>& plots_json) {
+
+    // Plots are in JSON format. Parse these files
 
     // Get the list of plots to draw
     std::vector<Plot> plots;
@@ -55,6 +144,26 @@ bool execute(const std::string& datasets_json, const std::vector<std::string>& p
         for (auto it = root.begin(); it != root.end(); it++) {
             Plot p = {it.name(), (*it)["variable"].asString(), (*it)["plot_cut"].asString(), (*it)["binning"].asString()};
             plots.push_back(p);
+        }
+    }
+
+    return execute(datasets_json, plots);
+}
+
+bool execute(const std::string& datasets_json, const std::vector<Plot>& plots) {
+    // Setting the TVirtualTreePlayer
+    TVirtualTreePlayer::SetPlayer("TMultiDrawTreePlayer");
+
+    // Getting the list of samples    
+    Json::Value samplesroot;
+    {
+        std::ifstream config_doc(datasets_json);
+
+        Json::Reader samplesreader;
+        bool parsingSuccessful = samplesreader.parse(config_doc, samplesroot, false);
+        if (!parsingSuccessful) {
+            std::cerr << "Failed to parse '" << datasets_json << "'" << std::endl;
+            return false;
         }
     }
 
@@ -120,7 +229,19 @@ int main( int argc, char* argv[]) {
 
         cmd.parse(argc, argv);
 
-        return (execute(datasetArg.getValue(), plotsArg.getValue()) ? 0 : 1);
+        bool python = false;
+        const std::vector<std::string>& plots = plotsArg.getValue();
+        if (plots.size() == 1 && plots[0].substr(plots[0].find_last_of(".") + 1) == "py") {
+            python = true;
+        }
+
+        bool ret = false;
+        if (python)
+            ret = execute(datasetArg.getValue(), plots[0]);
+        else
+            ret = execute(datasetArg.getValue(), plots);
+
+        return (ret ? 0 : 1);
 
     } catch (TCLAP::ArgException &e) {
         std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl;

--- a/plotUtils/plots/example.py
+++ b/plotUtils/plots/example.py
@@ -1,0 +1,7 @@
+plots = {
+        'dimuon_mass': {
+            'variable': 'hh_dimuons.M()',
+            'plot_cut': '(hh_dimuons.M() > 20.) * event_weight',
+            'binning': '(1000, 0, 1000)'
+            }
+        }


### PR DESCRIPTION
As we discussed yesterday, this PR implements the changes needed to be able to define the plots in a python script.

The only requirement here is that the script must declare a global variable named ``plots``, which must be a dictionary with the exact same format as the json files.

You can still use the old JSON files, the script automatically detects how to parse the file based on the file extension. In the case of python file, only 1 input file is supported for the moment.