### PR TITLE
Fix multi-histogram drawing

### DIFF
--- a/histFactory/CMakeLists.txt
+++ b/histFactory/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MULTIDRAW_SOURCES
     src/createHistoWithMultiDraw.cpp
     ${EXTERNAL_SRC_DIR}/jsoncpp.cpp
     ${EXTERNAL_SRC_DIR}/TMultiDrawTreePlayer.cxx
+    ${EXTERNAL_SRC_DIR}/TSelectorMultiDraw.cxx
     ${MD_DICTIONARY}
     )
 

--- a/histFactory/cmake/modules/BuildExternals.cmake
+++ b/histFactory/cmake/modules/BuildExternals.cmake
@@ -11,7 +11,7 @@ set(JSONCPP_VERSION "1.6.5")
 set(JSONCPP_TAR "jsoncpp-${JSONCPP_VERSION}.tar.gz")
 set(JSONCPP_DIR ${EXTERNAL_DIR}/jsoncpp-${JSONCPP_VERSION})
 
-set(MD_VERSION "1.0")
+set(MD_VERSION "1.1.1")
 set(MD_TAR "TMultiDrawTreePlayer-${MD_VERSION}.tar.gz")
 set(MD_DIR ${EXTERNAL_DIR}/TMultiDrawTreePlayer-${MD_VERSION})
 
@@ -46,7 +46,9 @@ if (NOT EXTERNAL_BUILT)
     execute_process(COMMAND curl -L "https://github.com/blinkseb/TMultiDrawTreePlayer/archive/v${MD_VERSION}.tar.gz" -o "${MD_TAR}" WORKING_DIRECTORY ${EXTERNAL_DIR})
     execute_process(COMMAND tar xf ${MD_TAR} WORKING_DIRECTORY ${EXTERNAL_DIR})
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${MD_DIR}/TMultiDrawTreePlayer.cxx ${EXTERNAL_SRC_DIR})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${MD_DIR}/TSelectorMultiDraw.cxx ${EXTERNAL_SRC_DIR})
     execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${MD_DIR}/TMultiDrawTreePlayer.h ${EXTERNAL_INCLUDE_DIR})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${MD_DIR}/TSelectorMultiDraw.h ${EXTERNAL_INCLUDE_DIR})
 
     MESSAGE(STATUS "Building TCLAP")
     execute_process(COMMAND curl -L "http://downloads.sourceforge.net/project/tclap/tclap-1.2.1.tar.gz?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Ftclap%2Ffiles%2F&ts=1431017326&use_mirror=freefr" -o "${TCLAP_TAR}" WORKING_DIRECTORY ${EXTERNAL_DIR})

--- a/histFactory/src/createHistoWithMultiDraw.cpp
+++ b/histFactory/src/createHistoWithMultiDraw.cpp
@@ -16,6 +16,7 @@
 #include <TTree.h>
 #include <TFile.h>
 #include <TApplication.h>
+#include <TObject.h>  // For kWriteDelete
 
 #include <tclap/CmdLine.h>
 
@@ -215,7 +216,7 @@ bool execute(const std::string& datasets_json, const std::vector<Plot>& plots) {
         // Looping over the different plots
         for (auto& p: plots) {
             std::string plot_var = p.variable + ">>" + p.name + p.binning;
-            player->queueDraw(plot_var.c_str(), p.plot_cut.c_str());
+            player->queueDraw(plot_var.c_str(), p.plot_cut.c_str(), "goff");
         }
 
         player->execute();
@@ -223,10 +224,10 @@ bool execute(const std::string& datasets_json, const std::vector<Plot>& plots) {
         for (auto& p: plots) {
             TObject* obj = gDirectory->Get(p.name.c_str());
             if (obj)
-                obj->Write();
+                obj->Write(nullptr, TObject::kOverwrite);
         }
 
-        outfile->Write();
+        outfile->Write(nullptr, TObject::kOverwrite);
     }
 
     return true;


### PR DESCRIPTION
When drawing more than one histogram, it happends that some are filled
with wrong values. Root cause is not yet fully understood, but v1.1.1
of TMultiDrawTreePlayer seems to fix the issue. When this occurs, the
TTreeFormula used to fill the histogram returns incorrect values.

Closes #26 

@swertz Can you confirm it solves your issue? From my test, it seems so, but another :+1: would be great!