### PR TITLE
Support for multiple runs per dataset

### DIFF
--- a/histFactory/CMakeLists.txt
+++ b/histFactory/CMakeLists.txt
@@ -83,6 +83,8 @@ target_link_libraries(multidraw ${ROOT_LIBRARIES})
 target_link_libraries(multidraw ${ROOT_TREEPLAYER_LIBRARY})
 target_link_libraries(multidraw ${PYTHON_LIBRARY})
 
+target_link_libraries(multidraw "uuid")
+
 target_link_libraries(count ${ROOT_LIBRARIES})
 
 # Ensure C++11 is available

--- a/histFactory/condorTools.py
+++ b/histFactory/condorTools.py
@@ -156,7 +156,7 @@ popd
             for fileList in fileListList:
 
                 jsonFileName = os.path.join(self.inDir, "samples_{}.json".format(jobCount) )
-                outputFile = name + "_histos_{}".format(jobCount) + ".root"
+                outputFile = name + "_histos_{}".format(jobCount)
                 
                 dico = {}
                 dico["#JOB_ID#"] = str(jobCount)
@@ -164,7 +164,7 @@ popd
                 dico["#SAMPLE_JSON#"] = jsonFileName 
                 dico["#INDIR_PATH#"] = self.inDir
                 dico["#OUTDIR_PATH#"] = self.outDir
-                dico["#OUTPUT_FILE#"] = outputFile 
+                dico["#OUTPUT_FILE#"] = outputFile + '.root'
                 dico["#LOGDIR_RELPATH#"] = os.path.relpath(self.logDir)
                 dico["#EXEC_PATH#"] = self.execPath
                 dico["#PLOT_CFG_PATH#"] = self.plotConfig

--- a/histFactory/test/plots.py
+++ b/histFactory/test/plots.py
@@ -1,0 +1,31 @@
+# The current dataset is accessible from the global variable 'dataset'
+print dataset
+
+# Any change made to this dict will be reflected into histFactory (very useful to change the output file name)
+
+# Any options passed to the 'runs' are available as a 'options' dict global variable. If you look in the 'sample.json' file, you'll see it defines a 'tt_type' options.
+print options
+
+tt_type = None
+if 'tt_type' in options:
+    tt_type = options['tt_type']
+
+# This directly change the name of the output file!
+dataset["output_name"] += "_" + tt_type
+
+# Add a plot based on the current tt decay type
+
+cut = "(tt_gen_ttbar_decay_type "
+if tt_type == "hadronic":
+    cut += " == 1"
+else:
+    cut += " > 1"
+
+cut += ')'
+
+plots = [{
+            'name': 'll_M_CAT_ElEl_IDMM_IsoLL',
+            'variable': 'tt_diLeptons[ tt_diLeptons_IDIso[36][0] ].p4.M()',
+            'plot_cut': '(((((elel_Category_IDMM_IsoLL_cut)&&(elel_Mll_IDMM_IsoLL_cut)&&(elel_DiLeptonTriggerMatch_IDMM_IsoLL_cut)&&(elel_DiLeptonIsOS_IDMM_IsoLL_cut)))&&(1)))*event_weight*' + cut,
+            'binning': '(100, 0, 800)'
+        }]

--- a/histFactory/test/sample.json
+++ b/histFactory/test/sample.json
@@ -1,0 +1,18 @@
+{
+    "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2_v1.0.0+7415_TTAnalysis_12d3865": {
+        "tree_name": "t",
+        "files": [
+            "/storage/data/cms/store/user/sbrochet/TT_TuneCUETP8M1_13TeV-powheg-pythia8/TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2/151021_071654/0000/output_mc_1.root"
+        ],
+        "db_name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2_v1.0.0+7415_TTAnalysis_12d3865",
+        "sample_cut": "1.",
+        "runs": [
+            {
+                "tt_type": "hadronic"
+            },
+            {
+                "tt_type": "dileptonic"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
A 'run' consists of a set of options which are passed to the python
script, which can be used to customize the set of plots to produce,
or change the cuts, or basically anything the user wants. The script
will be executed N times for each dataset, one time per run specified.

Runs are specified in the input JSON file, see `test/sample.json` for an
example.

The plots for all the various runs are done within the same event
loop, so if only the cut string is changed, runtime penalty should
be really small. Each set of plots for each run is saved in its own
file. You don't have to worry about name collision in different run,
it's handled automatically by the code to ensure each name are unique
during the plotting. Correct names are restored when saved into the output file.

Run options are accessible from the global dict 'options' in the
script (read only). In addition, the whole current dataset is also
accessible from the global dict 'dataset'. This variable is writable,
which mean the python script can and should change the output name
of the current name with a custom naming scheme to avoid file
overwrite.

As an example, see the python script `test/plots.py` which has some
inline comments.

Support for specifying the plots in JSON format has been removed, as it's not at all compatible with the new runs system.

This is RFC for the moment, I'm waiting for #29 to be merged in order to rebase over it.