### PR TITLE
Ensure binning and range info are respected

### DIFF
--- a/histFactory/src/createHistoWithMultiDraw.cpp
+++ b/histFactory/src/createHistoWithMultiDraw.cpp
@@ -113,6 +113,9 @@ std::string get_uuid() {
 
     uuid_unparse(out, &uuid[0]);
 
+    // Remove null terminator
+    uuid.resize(36);
+
     return uuid;
 }
 


### PR DESCRIPTION
Since introduction of multi-run, binning and range are no longer respected. It's because now the histogram names are changed to a random string to prevent clashes between runs. This string is generated with `uuid_unparse`, which returns a C string of 36 characters, plus a NULL terminator. However, `std::string` are not NULL terminated, so when concatenating this string with something (binning and range for example...) and converting it to C string (the one ROOT uses), you basically introduce a NULL character in the middle of your string.

Long story short, this PR removes the null terminator from the string.

Thanks to @swertz for spotting this issue.