### PR TITLE
Add small script to run over multiple datasets in parallel

### DIFF
--- a/histFactory/scripts/createPlotter.sh.in
+++ b/histFactory/scripts/createPlotter.sh.in
@@ -21,6 +21,7 @@ fi
 
 # Create output folder
 mkdir -p "$OUTPUT/build/external"
+mkdir -p "$OUTPUT/scripts"
 
 # Copy files
 cp -r "$PROJECT_DIR/cmake" "$OUTPUT"
@@ -30,6 +31,8 @@ cp "$TEMPLATES_DIR/generateHeader.sh" "$OUTPUT/"
 cp -r "$EXTERNAL_DIR/src" "$OUTPUT/build/external/"
 cp -r "$EXTERNAL_DIR/lib" "$OUTPUT/build/external/"
 cp -r "$EXTERNAL_DIR/include" "$OUTPUT/build/external/"
+
+cp "$PROJECT_DIR/scripts/parallelizedPlotter.py.in" "$OUTPUT/scripts/"
 
 # Generate C++ code
 ./createPlotter.exe -i "$SKELETON" -o "$OUTPUT" $CONFIG

--- a/histFactory/scripts/parallelizedPlotter.py.in
+++ b/histFactory/scripts/parallelizedPlotter.py.in
@@ -1,0 +1,53 @@
+#! /bin/env python
+
+"""
+Run N instances of the plotter in parallel on the datasets specified in input.
+"""
+
+import json
+import tempfile
+import subprocess
+
+def get_options():
+    """
+    Parse and return the arguments provided by the user.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Launch plotter multiple datasets.')
+
+    parser.add_argument('-j', '--cores', type=int, action='store', dest='processes', metavar='N', default='4',
+                        help='Number of core to use for parallel execution')
+
+    parser.add_argument('datasets', type=str, nargs='+', metavar='FILE',
+                        help='JSON files listings datasets to run over.')
+
+    options = parser.parse_args()
+
+    if options.datasets is None:
+        parser.error('You must specify at least one JSON file listing the datasets to run over.')
+
+    return options
+
+opt = get_options()
+
+datasets = {}
+for dataset_file in opt.datasets:
+    with open(dataset_file) as f:
+        datasets.update(json.load(f))
+
+def launch_plotter((dataset_name, dataset_data)):
+    PLOTTER_EXE = "@PROJECT_BINARY_DIR@/plotter.exe"
+
+    dataset = {dataset_name: dataset_data}
+    with tempfile.NamedTemporaryFile() as tmp:
+        json.dump(dataset, tmp)
+        tmp.flush()
+
+        cmd = [PLOTTER_EXE, '-d', tmp.name]
+        subprocess.call(cmd)
+
+
+from multiprocessing import Pool
+pool = Pool(processes=opt.processes)
+pool.map(launch_plotter, datasets.items())

--- a/histFactory/templates/CMakeLists.txt
+++ b/histFactory/templates/CMakeLists.txt
@@ -52,6 +52,9 @@ set(EXTERNAL_SRC_DIR "${EXTERNAL_DIR}/src")
 
 include_directories(${EXTERNAL_INCLUDE_DIR})
 
+# Create python script to parallelize the plotter
+configure_file(scripts/parallelizedPlotter.py.in parallelizedPlotter.py @ONLY NEWLINE_STYLE UNIX)
+
 set(PLOTTER_SOURCES
     Plotter.cc
     ${EXTERNAL_SRC_DIR}/jsoncpp.cpp


### PR DESCRIPTION
This script will be located in the same directory as `plotter.exe`. Usage is simple:

```
./parallelizedPlotter.py <myjson1> <myjson2> [...] -j 15
```

This will run the plotter on all datasets specified by the two files (one plotter instance per dataset) on 15 cores (so 15 instances in parallel).

If the `-j` option is missing, it runs on 4 cores.