### PR TITLE
2d plots and more

### DIFF
--- a/histFactory/templates/Plot.tpl
+++ b/histFactory/templates/Plot.tpl
@@ -1,5 +1,5 @@
         __weight = ({{CUT}});
         if (__weight != 0) {
-            {{HIST}}->Fill({{VAR}}, __weight);
+            fill({{HIST}}.get(), {{VAR}}, __weight);
         }
 

--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -134,6 +134,11 @@ int main(int argc, char** argv) {
 
             ROOT::TreeWrapper wrapped_tree(t.get());
 
+            // Set cache size to 10 MB
+            t->SetCacheSize(10 * 1024 * 1024);
+            // Learn tree structure from the first 10 entries
+            t->SetCacheLearnEntries(10);
+
             Plotter p(d, wrapped_tree);
             p.plot(output_file);
             std::cout << "Done. Output saved as '" << output_file << "'" << std::endl;

--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -9,6 +9,8 @@
 
 #include <TChain.h>
 #include <TH1F.h>
+#include <TH2F.h>
+#include <TH3F.h>
 #include <TFile.h>
 
 #include <json/json.h>

--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -10,6 +10,8 @@
 // ROOT
 #include <Rtypes.h>
 #include <TH1.h>
+#include <TH2.h>
+#include <TH3.h>
 #include <Math/Vector4D.h>
 
 // Generated automatically
@@ -89,6 +91,16 @@ class Plotter {
         template<typename T> typename std::enable_if<is_stl_container_like<T>::value, bool>::type fill(TH1* h, const T& value, double weight) {
             for (const auto& v: value)
                 h->Fill(v, weight);
+        }
+
+        // 2D
+        template<typename T, typename U> void fill(TH2* h, const T& value_x, const U& value_y, double weight) {
+            h->Fill(value_x, value_y, weight);
+        }
+
+        // 3D
+        template<typename T, typename U, typename V> void fill(TH3* h, const T& value_x, const U& value_y, const V& value_z, double weight) {
+            h->Fill(value_x, value_y, value_z, weight);
         }
 
         Dataset m_dataset;

--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -2,10 +2,14 @@
 
 #pragma once
 
-#include <Rtypes.h>
+#include <type_traits>
 #include <vector>
 #include <string>
 #include <map>
+
+// ROOT
+#include <Rtypes.h>
+#include <TH1.h>
 #include <Math/Vector4D.h>
 
 // Generated automatically
@@ -20,6 +24,42 @@ template<typename T>
 size_t Length$(const T& t) {
     return t.size();
 }
+
+// Traits to check if a given typename is iterable
+
+template<typename T> struct is_stl_container_like
+{
+    typedef typename std::remove_const<typename std::remove_reference<T>::type>::type test_type;
+
+    template<typename A> static constexpr bool test(
+            A * pt,
+            A const * cpt = nullptr,
+            decltype(pt->begin()) * = nullptr,
+            decltype(pt->end()) * = nullptr,
+            decltype(cpt->begin()) * = nullptr,
+            decltype(cpt->end()) * = nullptr,
+            typename A::iterator * pi = nullptr,
+            typename A::const_iterator * pci = nullptr,
+            typename A::value_type * pv = nullptr) {
+
+        typedef typename A::iterator iterator;
+        typedef typename A::const_iterator const_iterator;
+        typedef typename A::value_type value_type;
+        return  std::is_same<decltype(pt->begin()),iterator>::value &&
+            std::is_same<decltype(pt->end()),iterator>::value &&
+            std::is_same<decltype(cpt->begin()),const_iterator>::value &&
+            std::is_same<decltype(cpt->end()),const_iterator>::value &&
+            std::is_same<decltype(**pi),value_type &>::value &&
+            std::is_same<decltype(**pci),value_type const &>::value;
+
+    }
+
+    template<typename A> static constexpr bool test(...) {
+        return false;
+    }
+
+    static const bool value = test<test_type>(nullptr);
+};
 
 struct Dataset {
     std::string name;
@@ -40,6 +80,17 @@ class Plotter {
         void plot(const std::string&);
 
     private:
+
+        // Helper functions to fill an histogram
+        template<typename T> typename std::enable_if<!is_stl_container_like<T>::value, bool>::type fill(TH1* h, const T& value, double weight) {
+            h->Fill(value, weight);
+        }
+
+        template<typename T> typename std::enable_if<is_stl_container_like<T>::value, bool>::type fill(TH1* h, const T& value, double weight) {
+            for (const auto& v: value)
+                h->Fill(v, weight);
+        }
+
         Dataset m_dataset;
         ROOT::TreeWrapper& tree;
 


### PR DESCRIPTION
Another round of improvements for the plotter, in commit order:

 - Setup a 10 MB cache when reading the tree.
 - Plotting collections is now supported. Suppose you have a branch of type `std::vector<float>` named `jet_pt`, you can directly plot `jet_pt`. It works only for simple array, expressions like `jet_p4.Pt()` are not supported since they are not valid C++ (`std::vector` has no member named `Pt`) and for 1D histograms.
 - 2D and 3D histograms are now supported, same syntax as `TTree::Draw` (`x:y` or `x:y:z`).
 - Title and axis labels can now be set for each histogram in the python configuration, using `title`, `x-axis`, `y-axis` and `z-axis` attributes.