### PR TITLE
Rescale histograms using cross-section and sum of weights

### DIFF
--- a/histFactory/createSampleJson.py
+++ b/histFactory/createSampleJson.py
@@ -25,11 +25,16 @@ def createJson(indices, output):
     for isample in indices:
         sample = get_sample(isample)
 
+        if sample.source_dataset.xsection == 1.0:
+            print("Warning: cross-section for dataset %r not set." % sample.source_dataset.name)
+
         d = {}
         d["files"] = ["/storage/data/cms" + x.lfn for x in sample.files]
         d["db_name"] = sample.name
         d["tree_name"] = "t"
         d["sample_cut"] = "1."
+        d["event-weight-sum"] = sample.event_weight_sum
+        d["cross-section"] = sample.source_dataset.xsection
         samples[sample.name] = d
 
     with open(output, 'w') as fp:

--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -40,6 +40,8 @@ void Plotter::plot(const std::string& output_file) {
     }
 
     std::unique_ptr<TFile> outfile(TFile::Open(output_file.c_str(), "recreate"));
+
+    double sample_scale = m_dataset.cross_section / m_dataset.event_weight_sum;
 {{SAVE_PLOTS}}
 }
 
@@ -70,11 +72,22 @@ bool parse_datasets(const std::string& json_file, std::vector<Dataset>& datasets
         dataset.cut = sample.get("sample_cut", "1").asString();
         dataset.tree_name = sample.get("tree_name", "t").asString();
 
-        //dataset.output_name
         if (sample.isMember("output_name")) {
             dataset.output_name = sample["output_name"].asString();
         } else {
             dataset.output_name = dataset.db_name + "_histos";
+        }
+
+        if (sample.isMember("cross-section")) {
+            dataset.cross_section = sample["cross-section"].asDouble();
+        } else {
+            dataset.cross_section = 1.;
+        }
+
+        if (sample.isMember("event-weight-sum")) {
+            dataset.event_weight_sum = sample["event-weight-sum"].asDouble();
+        } else {
+            dataset.event_weight_sum = 1.;
         }
 
         // If a list of files is specified, only use those

--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -71,6 +71,8 @@ struct Dataset {
     std::string path;
     std::vector<std::string> files;
     std::string cut;
+    double cross_section;
+    double event_weight_sum;
 };
 
 class Plotter {

--- a/histFactory/templates/SavePlot.tpl
+++ b/histFactory/templates/SavePlot.tpl
@@ -1,3 +1,4 @@
+    {{UNIQUE_NAME}}->Scale(sample_scale);
     {{UNIQUE_NAME}}->SetName("{{PLOT_NAME}}");
     {{UNIQUE_NAME}}->Write("{{PLOT_NAME}}", TObject::kOverwrite);
 


### PR DESCRIPTION
Since we access the database to create the JSON sample file, it's easier to also retrieve the dataset cross-section and the sum of weights at this step than later when using plotIt.

Rescale all histograms with a factor `xsection / sum of weights`.