### PR TITLE
Added sample cut for plotter

### DIFF
--- a/histFactory/templates/CMakeLists.txt
+++ b/histFactory/templates/CMakeLists.txt
@@ -22,6 +22,8 @@ include_directories(${ROOT_INCLUDE_DIR})
 
 find_library(ROOT_GENVECTOR_LIB GenVector PATHS ${ROOT_LIBRARY_DIR}
     NO_DEFAULT_PATH)
+find_library(ROOT_TREEPLAYER_LIB TreePlayer PATHS ${ROOT_LIBRARY_DIR}
+    NO_DEFAULT_PATH)
 
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})
@@ -79,6 +81,7 @@ set_target_properties(plotter PROPERTIES OUTPUT_NAME "plotter.exe")
 # Link libraries
 target_link_libraries(plotter ${ROOT_LIBRARIES})
 target_link_libraries(plotter ${ROOT_GENVECTOR_LIB})
+target_link_libraries(plotter ${ROOT_TREEPLAYER_LIB})
 
 find_library(TREEWRAPPER_LIB cp3_llbbTreeWrapper PATHS
     "$ENV{CMSSW_BASE}/lib/$ENV{SCRAM_ARCH}" NO_DEFAULT_PATH)

--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -6,12 +6,15 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <memory>
 
 // ROOT
 #include <Rtypes.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TH3.h>
+#include <TTree.h>
+#include <TTreeFormula.h>
 #include <Math/Vector4D.h>
 
 // Generated automatically
@@ -75,9 +78,15 @@ struct Dataset {
 
 class Plotter {
     public:
-        Plotter(const Dataset& dataset, ROOT::TreeWrapper& tree):
-            m_dataset(dataset), tree(tree) {};
-        virtual ~Plotter() {};
+        Plotter(const Dataset& dataset, TTree* ttree):
+            m_dataset(dataset), tree(ttree), m_sample_cut(nullptr)
+            {
+                if(dataset.cut != "" && dataset.cut != "1"){
+                    m_sample_cut = new TTreeFormula("sample_cut", dataset.cut.c_str(), ttree);
+                    ttree->SetNotify(m_sample_cut);
+                }
+            };
+        virtual ~Plotter() { delete m_sample_cut; };
 
         void plot(const std::string&);
 
@@ -104,7 +113,8 @@ class Plotter {
         }
 
         Dataset m_dataset;
-        ROOT::TreeWrapper& tree;
+        ROOT::TreeWrapper tree;
+        TTreeFormula* m_sample_cut;
 
         // List of branches
         {{BRANCHES}}


### PR DESCRIPTION
Use a TTreeFormula to evaluate a sample cut, specified in the sample JSON, when running the generated plotter.

If the output name is retrieved from the database, the "suffix" field can be used in the JSON to modify the output name accordingly.

This allows to do some of the things that were possible using the "runs" of createHistoWithMultiDraw.