### PR TITLE
Separate weight from cut string

### DIFF
--- a/histFactory/templates/Plot.tpl
+++ b/histFactory/templates/Plot.tpl
@@ -1,5 +1,6 @@
-        __weight = ({{CUT}});
-        if (__weight != 0) {
+        __cut = ({{CUT}});
+        if (__cut) {
+            __weight = ({{WEIGHT}});
             fill({{HIST}}.get(), {{VAR}}, __weight);
         }
 

--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -37,6 +37,7 @@ void Plotter::plot(const std::string& output_file) {
         if ((index - 1) % 1000 == 0)
             std::cout << "Processing entry " << index << " of " << tree.getEntries() << std::endl;
 
+        bool __cut = false;
         double __weight = 0;
 
 {{PLOTS}}


### PR DESCRIPTION
It's not really practical to have the same line of code for the cut string and the weight. This commit separate the two by letting the python configuration to specify both a cut and a weight. If no weight is specified, 1 is used by default.

The weight is specified using the new `weight` entry in the dictionary. This formula is only evaluated iif the cut passed.

Also, as a side effect, I've changed the token used to split 2D and 3D histogram. Previously, it was `:`, but it's now `:::` (3 `:`), because `:` is valid C++ and strings like `(test ? 1. : 0.)` were split in two...

**Note**: all the python configuration will need to be updated to match the new expectation of the code. The `plot_cut` entry is now a `bool`, so you must removed any weight here. Specify your weights using the new `weight` entry.