### PR TITLE
[TTAnalysis] Basic scale factors support

### DIFF
--- a/histFactory/plots/TTAnalysis/ScaleFactors.py
+++ b/histFactory/plots/TTAnalysis/ScaleFactors.py
@@ -1,0 +1,93 @@
+from TTAnalysis import TT
+
+noScaleFactors = False
+
+def lepton_id_to_string(wp):
+    if wp == TT.LepID.L:
+        return 'loose'
+    elif wp == TT.LepID.M:
+        return 'medium'
+    elif wp == TT.LepID.T:
+        return 'tight'
+
+    raise Exception('Unknown lepton id working point')
+
+def lepton_iso_to_string(wp):
+    if wp == TT.LepIso.L:
+        return 'loose'
+    elif wp == TT.LepIso.T:
+        return 'tight'
+
+    raise Exception('Unknown lepton iso working point')
+
+def btag_wp_to_string(wp):
+    if wp == TT.BWP.L:
+        return 'loose'
+    elif wp == TT.BWP.M:
+        return 'medium'
+    elif wp == TT.BWP.T:
+        return 'tight'
+
+    raise Exception('Unknown b-tagging working point')
+
+def get_muon_iso_sf_branch(iso, id):
+    return 'muon_sf_iso_%s_id_%s' % (lepton_iso_to_string(iso), lepton_id_to_string(id))
+
+def get_muon_id_sf_branch(id):
+    return 'muon_sf_id_%s' % (lepton_id_to_string(id))
+
+def get_csvv2_sf_branch(wp):
+    return 'jet_sf_csvv2_%s' % (btag_wp_to_string(wp))
+
+# Lepton scale factors
+
+def get_dilepton_object(dilepton_index, id1, id2, iso1, iso2):
+    return 'tt_diLeptons[tt_diLeptons_IDIso[%d][%d]]' % (TT.LepLepIDIso(id1, iso1, id2, iso2), dilepton_index)
+
+def get_lepton_SF_for_dilepton(lepton_index, dilepton_index, id1, id2, iso1, iso2):
+    if noScaleFactors:
+        return "1."
+
+    pair_field = None
+    if lepton_index == 0:
+        pair_field = 'first'
+    else:
+        pair_field = 'second'
+
+    dilepton_object = get_dilepton_object(dilepton_index, id1, id2, iso1, iso2)
+
+    lepton_index = '%s.lidxs.%s' % (dilepton_object, pair_field)
+    lepton_object = 'tt_leptons[%s]' % lepton_index
+
+    lepton_id_sf = '(({0}.isEl) ? 1. : {1}[{0}.idx][0])'.format(lepton_object, get_muon_id_sf_branch(id1))
+    lepton_iso_sf = '(({0}.isEl) ? 1. : {1}[{0}.idx][0])'.format(lepton_object, get_muon_iso_sf_branch(iso1, id1))
+
+    return '%s * %s' % (lepton_id_sf, lepton_iso_sf)
+
+def get_leptons_SF_for_dilepton(dilepton_index, id1, id2, iso1, iso2):
+    return '%s * %s' % (get_lepton_SF_for_dilepton(0, dilepton_index, id1, id2, iso1, iso2), get_lepton_SF_for_dilepton(1, dilepton_index, id1, id2, iso1, iso2))
+
+# b-tagging scale factors
+
+def get_dijet_object(dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2):
+    return 'tt_diJets[tt_diLepDiJets[tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[%d][%d]].diJetIdx]' % (TT.LepLepIDIsoJetJetBWP(id1, iso1, id2, iso2, b1_wp, b2_wp), dijet_index)
+
+def get_at_least_two_b_SF_one_b_for_dijet(b_index, dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2):
+    if noScaleFactors:
+        return "1."
+
+    pair_field = None
+    if b_index == 0:
+        pair_field = 'first'
+    else:
+        pair_field = 'second'
+
+    dijet_object = get_dijet_object(dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2)
+
+    return '%s[%s.idxs.%s][0]' % (get_csvv2_sf_branch(b1_wp), dijet_object, pair_field)
+
+def get_at_least_two_b_SF_for_dijet(dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2):
+    first_bjet_sf  = get_at_least_two_b_SF_one_b_for_dijet(0, dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2)
+    second_bjet_sf = get_at_least_two_b_SF_one_b_for_dijet(1, dijet_index, b1_wp, b2_wp, id1, id2, iso1, iso2)
+
+    return "%s * %s" % (first_bjet_sf, second_bjet_sf)

--- a/histFactory/plots/TTAnalysis/TTAnalysis.py
+++ b/histFactory/plots/TTAnalysis/TTAnalysis.py
@@ -1,0 +1,13 @@
+import os
+import ROOT as R
+
+#### Get all the indices and functions definitions needed to retrieve the IDs/... ROOT can be awesome at times :) ####
+
+pathCMS = os.getenv("CMSSW_BASE")
+if pathCMS == "":
+    raise Exception("CMS environment is not valid!")
+pathTT = os.path.join(pathCMS, "src/cp3_llbb/TTAnalysis/")
+pathTTdefs = os.path.join(pathTT, "plugins/Indices.cc")
+
+R.gROOT.ProcessLine(".L " + pathTTdefs + "+")
+TT =  R.TTAnalysis

--- a/histFactory/plots/TTAnalysis/basePlots.py
+++ b/histFactory/plots/TTAnalysis/basePlots.py
@@ -56,7 +56,6 @@ ll = [
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#', 'tt_gen_ttbar_decay_type > 0'),
             'binning': (50, -6, 6)
         },
-
         # Lepton 1
         { 
             'name': 'lep1_pt_CAT_#CAT_TITLE#',
@@ -81,6 +80,13 @@ ll = [
             'variable': 'tt_leptons[ tt_diLeptons[ tt_diLeptons_IDIso[#LEPLEP_IDISO#][0] ].lidxs.first ].isoValue',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': (50, 0, 0.2)
+        },
+        { 
+            'name': 'lep1_SF_CAT_#CAT_TITLE#',
+            'variable': '#LEP1_SF#',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 1.5),
+            'scale-factors': False
         },
         
         # Lepton 2
@@ -107,6 +113,13 @@ ll = [
             'variable': 'tt_leptons[ tt_diLeptons[ tt_diLeptons_IDIso[#LEPLEP_IDISO#][0] ].lidxs.second ].isoValue',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': (50, 0, 0.2)
+        },
+        { 
+            'name': 'lep2_SF_CAT_#CAT_TITLE#',
+            'variable': '#LEP2_SF#',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 1.5),
+            'scale-factors': False
         },
         
         # DiLepton
@@ -502,6 +515,13 @@ llbb = [
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': (25, 0, 1)
         },
+        { 
+            'name': 'bjet1_SF_CAT_#CAT_TITLE#',
+            'variable': '#BJET1_SF#',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 1.5),
+            'scale-factors': False
+        },
         
         # BJet 2
         { 
@@ -533,6 +553,13 @@ llbb = [
             'variable': 'tt_selJets[ tt_diJets[ tt_diLepDiJets[ tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[#LEPLEP_IDISO_BBWP#][0] ].diJetIdx ].jidxs.second ].CSVv2',
             'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
             'binning': (25, 0, 1)
+        },
+        { 
+            'name': 'bjet2_SF_CAT_#CAT_TITLE#',
+            'variable': '#BJET2_SF#',
+            'plot_cut': joinCuts('#LEPLEP_CAT_CUTS#', '#JET_CAT_CUTS#'),
+            'binning': (50, 0, 1.5),
+            'scale-factors': False
         },
         
         # DiBJet

--- a/histFactory/plots/TTAnalysis/generatePlots.py
+++ b/histFactory/plots/TTAnalysis/generatePlots.py
@@ -52,6 +52,8 @@ categoryPlots = {
 # Initialize maps needed later
 for categ in categoryPlots.values():
     categ["strings"] = []
+    categ["weights"] = []
+
 
 flavourCategPlots = { flav: copy.deepcopy(categoryPlots) for flav in myFlavours }
 
@@ -88,11 +90,13 @@ for flav in flavourCategPlots.values():
     for categ in flav.values():
 
         # Iterate over each sub-category
-        for subCateg in categ["strings"]:
+        for subCateg_index, subCateg in enumerate(categ["strings"]):
 
             # Iterate over every plot skeleton defined for the current category group
             for plot in categ["plots"]:
                 m_plot = copy.deepcopy(plot)
+                if not 'scale-factors' in m_plot:
+                    m_plot['scale-factors'] = True
 
                 # Iterate over the string keys defined in the sub-category
                 for key in subCateg.items():
@@ -109,12 +113,14 @@ for flav in flavourCategPlots.values():
                 #if tt_cut is not None:
                 #    m_plot["plot_cut"] = joinCuts(m_plot["plot_cut"], tt_cut)
 
-                # Don't forget the event_weight:
-                m_plot["plot_cut"] = "(" + m_plot["plot_cut"] + ")*event_pu_weight*event_weight"
+                # Plot weights
+                m_plot["weight"] = "event_pu_weight * event_weight"
+                if len(categ["weights"][subCateg_index]) > 0 and m_plot['scale-factors']:
+                    m_plot["weight"] += " * " + " * ".join(categ["weights"][subCateg_index])
 
                 plots.append(m_plot)
 
-                print "Plot: {}\nVariable: {}\nCut: {}\nBinning: {}\n".format(m_plot["name"], m_plot["variable"], m_plot["plot_cut"], m_plot["binning"])
+                print "Plot: {}\nVariable: {}\nCut: {}\nWeight: {}\nBinning: {}\n".format(m_plot["name"], m_plot["variable"], m_plot["plot_cut"], m_plot["weight"], m_plot["binning"])
 
 print "Generated {} plots.\n".format(len(plots))
 

--- a/histFactory/plots/TTAnalysis/plotTools.py
+++ b/histFactory/plots/TTAnalysis/plotTools.py
@@ -1,17 +1,7 @@
-import os
 import copy
-import ROOT as R
 
-#### Get all the indices and functions definitions needed to retrieve the IDs/... ROOT can be awesome at times :) ####
-
-pathCMS = os.getenv("CMSSW_BASE")
-if pathCMS == "":
-    raise Exception("CMS environment is not valid!")
-pathTT = os.path.join(pathCMS, "src/cp3_llbb/TTAnalysis/")
-pathTTdefs = os.path.join(pathTT, "plugins/Indices.cc")
-
-R.gROOT.ProcessLine(".L " + pathTTdefs + "+")
-TT =  R.TTAnalysis
+from TTAnalysis import TT
+from ScaleFactors import *
 
 #### Utility to join different cuts together (logical AND) ####
 
@@ -32,12 +22,9 @@ def joinCuts(*cuts):
 
 #### The IDs/... we want to run on ####
 
-#electronID = { id.first: id.second for id in TT.LepID.map if id.second != "V" }
-#muonID = dict(TT.LepID.map)
-electronID = { TT.LepID.L: "L" }
+electronID = { TT.LepID.L: "L", TT.LepID.M: "M" }
 muonID = { TT.LepID.L: "L" }
 
-#muonIso = dict(TT.LepIso.map)
 electronIso = { TT.LepIso.L: "L" }
 muonIso = { TT.LepIso.L: "L" }
 
@@ -49,6 +36,8 @@ myFlavours = [ "ElEl", "MuEl", "ElMu", "MuMu" ]
 #myFlavours = [ "ElEl" ]
 #myFlavours = [ "MuMu" ]
 #myFlavours = [ "ElMu", "MuEl" ]
+
+keepOnlySymmetricWP = True
 
 #### UTILITY TO GENERATE ALL THE NEEDED CATEGORIES ####
 
@@ -95,7 +84,15 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
         for id2 in lep2IDs:
             for iso1 in lep1Isos:
                 for iso2 in lep2Isos:
-                    
+
+                    if keepOnlySymmetricWP and id1 != id2:
+                        continue
+
+                    if keepOnlySymmetricWP and iso1 != iso2:
+                        continue
+
+                    llSFs = [get_leptons_SF_for_dilepton(0, id1, id2, iso1, iso2)]
+
                     # ll categs: iterate over two leptons ID & isolation
 
                     lepLepIDIsoStr = TT.LepLepIDIsoStr(id1, iso1, id2, iso2)
@@ -111,6 +108,8 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                                 ),
                             "#MIN_LEP_IDISO#": TT.LepIDIso(min(id1, id2), min(iso1, iso2)),
                             "#JET_CAT_CUTS#": "1",
+                            "#LEP1_SF#": get_lepton_SF_for_dilepton(0, 0, id1, id2, iso1, iso2),
+                            "#LEP2_SF#": get_lepton_SF_for_dilepton(1, 0, id1, id2, iso1, iso2)
                         }
                     llStrings = [ copy.deepcopy(llStringsBase) ]
                     
@@ -127,18 +126,24 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                         llStrings.append(m_llStrings)
 
                     if "llCategs" in categoryStringsDico.keys():
-                    
                         categoryStringsDico["llCategs"]["strings"] += llStrings
+                        categoryStringsDico["llCategs"]["weights"] += [llSFs]
+
+                        if doZVeto:
+                            categoryStringsDico["llCategs"]["weights"] += [llSFs]
     
                     # lljj categs: two jets; minDRjl > cut using loosest of the two IDs & isolations
 
                     if "lljjCategs" in categoryStringsDico.keys():
                     
                         lljjStrings = copy.deepcopy(llStrings)
+                        weights = []
                         for categ in lljjStrings:
                             categ["#CAT_TITLE#"] += "_jj"
                             categ["#JET_CAT_CUTS#"] = "Length$(tt_diLepDiJets_DRCut[" + str(TT.LepLepIDIso(id1, iso1, id2, iso2)) + "]) >= 1"
+                            weights += [llSFs]
                         categoryStringsDico["lljjCategs"]["strings"] += lljjStrings
+                        categoryStringsDico["lljjCategs"]["weights"] += weights
     
                     # lljj_b_categs: two jets, but iterate over one b-jet working point
 
@@ -146,14 +151,17 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                     
                         for wp in myBWPs.items():
                             lljj_b_Strings = copy.deepcopy(llStrings)
-                            
+                            weights = [] 
+
                             for categ in lljj_b_Strings:
                                 categ["#CAT_TITLE#"] += "_jj_b_" + wp[1]
                                 categ["#BWP#"] = wp[1]
                                 categ["#MIN_LEP_IDISO_BWP#"] = TT.LepIDIsoJetBWP(min(id1, id2), min(iso1, iso2), wp[0])
                                 categ["#JET_CAT_CUTS#"] = "Length$(tt_diLepDiJets_DRCut[" + str(TT.LepLepIDIso(id1, iso1, id2, iso2)) + "]) >= 1"
+                                weights += [llSFs]
                             
                             categoryStringsDico["lljj_b_Categs"]["strings"] += lljj_b_Strings
+                            categoryStringsDico["lljj_b_Categs"]["weights"] += weights
 
                     # llbj_categs: two jets, one b-jet, iterate over one b-jet working point
 
@@ -161,6 +169,10 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                     
                         for wp in myBWPs.items():
                             llbjStrings = copy.deepcopy(llStrings)
+                            # FIXME
+                            #llbSFs = [get_leptons_SF_for_dilepton(0, id1, id2, iso1, iso2), get_at_least_one_b_SF(0, wp, id1, id2, iso1, iso2)]
+                            llbSFs = [get_leptons_SF_for_dilepton(0, id1, id2, iso1, iso2)]
+                            weights = []
                             
                             for categ in llbjStrings:
                                 categ["#CAT_TITLE#"] += "_bj_" + wp[1]
@@ -170,8 +182,10 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                                         "Length$(tt_diLepDiJets_DRCut[" + str(TT.LepLepIDIso(id1, iso1, id2, iso2)) + "]) >= 1"
                                         "Length$(tt_selBJets_DRCut_BWP_CSVv2Ordered[" + str(TT.LepIDIsoJetBWP(min(id1, id2), min(iso1, iso2), wp[0])) + "]) >= 1"
                                         )
+                                weights += [llbSFs]
                             
                             categoryStringsDico["llbjCategs"]["strings"] += llbjStrings
+                            categoryStringsDico["llbjCategs"]["weights"] += weights
 
                     # llbb categs: two b-jets, iterate over both b-jet working points
     
@@ -179,24 +193,34 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                     
                         for wp1 in myBWPs.keys():
                             for wp2 in myBWPs.keys():
+                                llbbSFs = [get_leptons_SF_for_dilepton(0, id1, id2, iso1, iso2), get_at_least_two_b_SF_for_dijet(0, wp1, wp2, id1, id2, iso1, iso2)]
+
                                 llbbStrings = copy.deepcopy(llStrings)
+                                weights = []
                                 
                                 for categ in llbbStrings:
                                     categ["#CAT_TITLE#"] += "_bb_" + TT.JetJetBWPStr(wp1, wp2)
                                     categ["#LEPLEP_IDISO_BBWP#"] = TT.LepLepIDIsoJetJetBWP(id1, iso1, id2, iso2, wp1, wp2)
                                     categ["#JET_CAT_CUTS#"] = "Length$(tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[" + str(TT.LepLepIDIsoJetJetBWP(id1, iso1, id2, iso2, wp1, wp2)) + "]) >= 1"
+                                    categ["#BJET1_SF#"] = get_at_least_two_b_SF_first_b_for_dijet(0, wp1, wp2, id1, id2, iso1, iso2)
+                                    categ["#BJET2_SF#"] = get_at_least_two_b_SF_second_b_for_dijet(0, wp1, wp2, id1, id2, iso1, iso2)
+                                    weights += [llbbSFs]
                                 
                                 categoryStringsDico["llbbCategs"]["strings"] += llbbStrings
+                                categoryStringsDico["llbbCategs"]["weights"] += weights
 
 
                     # Duplicate everything and ask for MET if we are same-flavour
                     
                     if flavourChannel in ["ElEl", "MuMu"]:
-                        for categGroup in categoryStringsDico.values():
+                        for categName, categGroup in categoryStringsDico.items():
                             metStrings = []
-                            for categ in categGroup["strings"]:
+                            weights = []
+                            for index, categ in enumerate(categGroup["strings"]):
                                 thisCateg = copy.deepcopy(categ)
                                 thisCateg["#CAT_TITLE#"] += "_noHFMet"
                                 thisCateg["#JET_CAT_CUTS#"] = joinCuts(thisCateg["#JET_CAT_CUTS#"], "nohf_met_p4.Pt() > 40")
                                 metStrings.append(thisCateg)
+                                weights.append(categGroup["weights"][index])
                             categGroup["strings"] += metStrings
+                            categGroup["weights"] += weights

--- a/histFactory/plots/TTAnalysis/plotTools.py
+++ b/histFactory/plots/TTAnalysis/plotTools.py
@@ -202,25 +202,24 @@ def generateCategoryStrings(categoryStringsDico, flavourChannel):
                                     categ["#CAT_TITLE#"] += "_bb_" + TT.JetJetBWPStr(wp1, wp2)
                                     categ["#LEPLEP_IDISO_BBWP#"] = TT.LepLepIDIsoJetJetBWP(id1, iso1, id2, iso2, wp1, wp2)
                                     categ["#JET_CAT_CUTS#"] = "Length$(tt_diLepDiBJets_DRCut_BWP_CSVv2Ordered[" + str(TT.LepLepIDIsoJetJetBWP(id1, iso1, id2, iso2, wp1, wp2)) + "]) >= 1"
-                                    categ["#BJET1_SF#"] = get_at_least_two_b_SF_first_b_for_dijet(0, wp1, wp2, id1, id2, iso1, iso2)
-                                    categ["#BJET2_SF#"] = get_at_least_two_b_SF_second_b_for_dijet(0, wp1, wp2, id1, id2, iso1, iso2)
+                                    categ["#BJET1_SF#"] = get_at_least_two_b_SF_one_b_for_dijet(0, 0, wp1, wp2, id1, id2, iso1, iso2)
+                                    categ["#BJET2_SF#"] = get_at_least_two_b_SF_one_b_for_dijet(1, 0, wp1, wp2, id1, id2, iso1, iso2)
                                     weights += [llbbSFs]
                                 
                                 categoryStringsDico["llbbCategs"]["strings"] += llbbStrings
                                 categoryStringsDico["llbbCategs"]["weights"] += weights
 
 
-                    # Duplicate everything and ask for MET if we are same-flavour
-                    
-                    if flavourChannel in ["ElEl", "MuMu"]:
-                        for categName, categGroup in categoryStringsDico.items():
-                            metStrings = []
-                            weights = []
-                            for index, categ in enumerate(categGroup["strings"]):
-                                thisCateg = copy.deepcopy(categ)
-                                thisCateg["#CAT_TITLE#"] += "_noHFMet"
-                                thisCateg["#JET_CAT_CUTS#"] = joinCuts(thisCateg["#JET_CAT_CUTS#"], "nohf_met_p4.Pt() > 40")
-                                metStrings.append(thisCateg)
-                                weights.append(categGroup["weights"][index])
-                            categGroup["strings"] += metStrings
-                            categGroup["weights"] += weights
+    # Duplicate everything and ask for MET if we are same-flavour
+    if flavourChannel in ["ElEl", "MuMu"]:
+        for categName, categGroup in categoryStringsDico.items():
+            metStrings = []
+            weights = []
+            for index, categ in enumerate(categGroup["strings"]):
+                thisCateg = copy.deepcopy(categ)
+                thisCateg["#CAT_TITLE#"] += "_Met"
+                thisCateg["#JET_CAT_CUTS#"] = joinCuts(thisCateg["#JET_CAT_CUTS#"], "met_p4.Pt() > 40")
+                metStrings.append(thisCateg)
+                weights.append(categGroup["weights"][index])
+            categGroup["strings"] += metStrings
+            categGroup["weights"] += weights


### PR DESCRIPTION
Note: based on #57 

As title say, introduce basic support for SF for the TTAnalysis. It not as flexible as I'd hoped, and it'll break if we decide to not use the first di-lepton / di-jet pair, but for the moment it'll do the job.

Since we use an easy selection SFs wise, the following weights are applied:
  - di-lepton categories: product of the leptons SFs
  - di-lepton and at least 2 b-jets categories: product of the lepton SFs and b-tag SFs

Some are possibly missing, can you have a look @swertz?