### PR TITLE
Add basic error detection in condor tools

### DIFF
--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -156,8 +156,15 @@ int main(int argc, char** argv) {
 
             std::cout << "Creating plots for dataset '" << d.name << "'" << std::endl;
             std::unique_ptr<TChain> t(new TChain(d.tree_name.c_str()));
+            bool fail_if_open_error = d.path.length() == 0;
+            size_t n_files = 0;
             for (const std::string& file: d.files)
-                t->Add(file.c_str());
+                n_files += t->Add(file.c_str(), 0);
+
+            if ((fail_if_open_error) && (n_files != d.files.size())) {
+                std::cerr << "Error: some files failed to open" << std::endl;
+                return 2;
+            }
 
             std::string output_file = output_dir + "/" + d.output_name + ".root";
 


### PR DESCRIPTION
Rarely, I've seen some cases where a job running on condor failed to open one or many (but not all) input files. The job would still succeed, but some events will be missing and it's really hard to detect, except inspecting all the error logs of all the jobs.

This is what this PR does. Before merging the files, it checks that all the error logs of all jobs are empty. If not, it warns the user and exit, otherwise, the files are merged as usual.