### PR TITLE
resubmit script

### DIFF
--- a/treeFactory/resubmit.py
+++ b/treeFactory/resubmit.py
@@ -1,0 +1,41 @@
+import os, sys
+
+#usage from treefactory : python resubmit.py 'yourCondorDir' [submit]
+
+condorDir = sys.argv[1]
+logDir = condorDir+"/logs/"
+failedJobIDs = []
+
+for file in os.listdir(logDir) : 
+    if ".err" in file and os.stat(logDir+file).st_size != 0 :
+        failedJobID =  file.split(".err")[0].split("_")[1]
+        failedJobIDs.append(failedJobID)
+
+if failedJobIDs == [] :
+    print "All jobs succeeded ;-)"
+    sys.exit()
+
+print "Jobs ", failedJobIDs, " have failed."
+resubmitFileName = "%s/input/resubmit.cmd"%condorDir
+os.system("cp %s/input/condor.cmd %s"%(condorDir, resubmitFileName))
+cmdFile = open(resubmitFileName, "r")
+cmdFileText = cmdFile.read()
+lineToPaste = cmdFileText[cmdFileText.find("arguments"):]
+
+cmdFile = open(resubmitFileName, "w")
+cmdFile.write(cmdFileText.replace(lineToPaste,""))
+
+for line in lineToPaste.split("\n") :
+    if ("queue" in line):
+        lineToPaste = lineToPaste.replace(line,"queue 1\n")
+
+for id in failedJobIDs : 
+    templineToPaste = lineToPaste.replace("$(Process)", id)
+    cmdFile.write(templineToPaste)
+cmdFile.close()
+
+if len(sys.argv) > 2 :
+    if sys.argv[2] == "submit":
+        os.system("condor_submit %s"%(resubmitFileName))
+else : 
+    print "If you want to submit the jobs type : python resubmit.py 'yourCondorDir' submit"


### PR DESCRIPTION
This is a script allowing to resubmit the failed jobs on condor (see PR #59 ). It is a bit ugly but it should work. Here is an example how to use it from treeFactory : 
`python resubmit.py sameFlavour_2016_01_06/condor/` [submit]
The optional `submit` should be put only if you want the failed jobs to be actually resubmitted.
I have tested it from histFactory with : 
 `python ../treefactory/resubmit.py sameFlavour_2016_01_06/condor/` [submit]
and it worked as well. Hope it can be useful for you as well.