### PR TITLE
Bump min. cmake version to 2.8

### DIFF
--- a/histFactory/CMakeLists.txt
+++ b/histFactory/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8)
 project (histFactory)
 
 # Configure paths

--- a/histFactory/templates/CMakeLists.txt.tpl
+++ b/histFactory/templates/CMakeLists.txt.tpl
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8)
 project (Plotter)
 
 # Configure paths

--- a/treeFactory/CMakeLists.txt
+++ b/treeFactory/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8)
 project (treeFactory)
 
 # Configure paths

--- a/treeFactory/templates/CMakeLists.txt
+++ b/treeFactory/templates/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8)
 project (Skimmer)
 
 # Configure paths


### PR DESCRIPTION
There's an issue while looking for boost  with cmake 2.6 and the build fails with **cryptic** errors, so, until I found a proper fix, just bump the cmake version to 2.8 to remind the user to use `cmake28` instead of `cmake`