### PR TITLE
cmake 2.6 is enough to build plotters / skimmers

### DIFF
--- a/histFactory/templates/CMakeLists.txt.tpl
+++ b/histFactory/templates/CMakeLists.txt.tpl
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.6)
 project (Plotter)
 
 # Configure paths

--- a/treeFactory/templates/CMakeLists.txt
+++ b/treeFactory/templates/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.6)
 project (Skimmer)
 
 # Configure paths


### PR DESCRIPTION
I was a bit to prompt when I bumped minimum version to 2.8. It's not needed for plotters / skimmers build, and it actually breaks everything, sorry!