### PR TITLE
Support alternative normalization in histFactory

### DIFF
--- a/histFactory/condorTools.py
+++ b/histFactory/condorTools.py
@@ -52,22 +52,25 @@ class condorSubmitter:
 
             rescale_sample = rescale
 
+            is_data = False
             if dbSample.source_dataset.datatype == u"data":
                 rescale_sample = False
+                is_data = True
+
+            sample["is-data"] = is_data
 
             if rescale_sample and dbSample.source_dataset.xsection == 1.0:
                 print("Warning: cross-section for dataset %r not set." % dbSample.source_dataset.name)
 
+            sample["extras-event-weight-sum"] = {}
             if rescale_sample:
                 sample["event-weight-sum"] = dbSample.event_weight_sum
                 sample["cross-section"] = dbSample.source_dataset.xsection
+                if len(dbSample.extras_event_weight_sum) > 0:
+                    sample["extras-event-weight-sum"] = json.loads(dbSample.extras_event_weight_sum)
             else :
                 sample["event-weight-sum"] = 1.
                 sample["cross-section"] = 1.
-
-
-
-
 
             # If a path to a json skeleton was provided, use it, otherwise use the default
             if "json_skeleton" in sample.keys():
@@ -85,7 +88,9 @@ class condorSubmitter:
                                 "sample_cut": "1.",
                                 "db_name": sample["db_name"],
                                 "event-weight-sum": sample["event-weight-sum"],
-                                "cross-section": sample["cross-section"]
+                                "extras-event-weight-sum": sample["extras-event-weight-sum"],
+                                "cross-section": sample["cross-section"],
+                                "is-data": sample["is-data"]
                             }
                         }
 

--- a/histFactory/templates/EnsureNormalization.tpl
+++ b/histFactory/templates/EnsureNormalization.tpl
@@ -1,0 +1,3 @@
+    if (!m_dataset.is_data && (m_dataset.extras_event_weight_sum.count("{{NAME}}") == 0)) {
+        throw std::runtime_error("Normalization '{{NAME}}' not found for this dataset");
+    }

--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -76,6 +76,8 @@ struct Dataset {
     std::string cut;
     double cross_section;
     double event_weight_sum;
+    std::map<std::string, double> extras_event_weight_sum;
+    bool is_data;
 };
 
 class Plotter {

--- a/histFactory/templates/SavePlot.tpl
+++ b/histFactory/templates/SavePlot.tpl
@@ -1,4 +1,5 @@
-    {{UNIQUE_NAME}}->Scale(sample_scale);
+    if (!m_dataset.is_data)
+        {{UNIQUE_NAME}}->Scale({{SAMPLE_SCALE}});
     {{UNIQUE_NAME}}->SetName("{{PLOT_NAME}}");
     {{UNIQUE_NAME}}->Write("{{PLOT_NAME}}", TObject::kOverwrite);
 

--- a/histFactory/test/plots.py
+++ b/histFactory/test/plots.py
@@ -1,31 +1,17 @@
-# The current dataset is accessible from the global variable 'dataset'
-print dataset
-
-# Any change made to this dict will be reflected into histFactory (very useful to change the output file name)
-
-# Any options passed to the 'runs' are available as a 'options' dict global variable. If you look in the 'sample.json' file, you'll see it defines a 'tt_type' options.
-print options
-
-tt_type = None
-if 'tt_type' in options:
-    tt_type = options['tt_type']
-
-# This directly change the name of the output file!
-dataset["output_name"] += "_" + tt_type
-
-# Add a plot based on the current tt decay type
-
-cut = "(tt_gen_ttbar_decay_type "
-if tt_type == "hadronic":
-    cut += " == 1"
-else:
-    cut += " > 1"
-
-cut += ')'
-
-plots = [{
-            'name': 'll_M_CAT_ElEl_IDMM_IsoLL',
-            'variable': 'tt_diLeptons[ tt_diLeptons_IDIso[36][0] ].p4.M()',
-            'plot_cut': '(((((elel_Category_IDMM_IsoLL_cut)&&(elel_Mll_IDMM_IsoLL_cut)&&(elel_DiLeptonTriggerMatch_IDMM_IsoLL_cut)&&(elel_DiLeptonIsOS_IDMM_IsoLL_cut)))&&(1)))*event_weight*' + cut,
+plots = [
+        {
+            'name': 'test_1',
+            'variable': 'electron_p4[0].Pt()',
+            'plot_cut': 'electron_p4.size() > 0',
             'binning': '(100, 0, 800)'
-        }]
+        },
+
+        {
+            'name': 'test_normalize_to',
+            'variable': 'electron_p4[0].Pt()',
+            'plot_cut': 'electron_p4.size() > 0',
+            'binning': '(100, 0, 800)',
+            "normalize-to": "pdf_up"
+        },
+
+        ]

--- a/scripts/createSampleJson.py
+++ b/scripts/createSampleJson.py
@@ -27,8 +27,10 @@ def createJson(indices, output, rescale):
 
         rescale_sample = rescale
 
+        is_data = False
         if sample.source_dataset.datatype == u"data":
             rescale_sample = False
+            is_data = True
 
         if rescale_sample and sample.source_dataset.xsection == 1.0:
             print("Warning: cross-section for dataset %r not set." % sample.source_dataset.name)
@@ -39,10 +41,13 @@ def createJson(indices, output, rescale):
         d["db_name"] = sample.name
         d["tree_name"] = "t"
         d["sample_cut"] = "1."
+        d["is-data"] = is_data
 
         if rescale_sample:
             d["event-weight-sum"] = sample.event_weight_sum
             d["cross-section"] = sample.source_dataset.xsection
+            if len(sample.extras_event_weight_sum) > 0:
+                d["extras-event-weight-sum"] = json.loads(sample.extras_event_weight_sum)
 
         samples[sample.name] = d
 


### PR DESCRIPTION
First commit adds support for extra sum of event weights introduced in https://github.com/cp3-llbb/Framework/pull/147, https://github.com/cp3-llbb/SAMADhi/pull/11 and https://github.com/cp3-llbb/GridIn/pull/69 in the sample JSON file.

Second commit adds support for normalization others than nominal in histFactory. To do this, a new option is added to the python definition of plots, `normalize-to`. Default value is `nominal` so nothing change, but you can also specify for example `pdf_up` or `pdf_down` to normalize wrt the sum of event weight for PDF up or down.

Based on @AlexandreMertens suggestion, I also added a 'is-data' flag to the input JSON file. Rescaling of histograms occurs only if running over MC, not over data, so it's safe to use the `normalize-to` option even on data.