### PR TITLE
Add helper to create scale variation systematic histograms

### DIFF
--- a/scripts/createScaleSystematics.py
+++ b/scripts/createScaleSystematics.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+
+import argparse
+import sys
+
+parser = argparse.ArgumentParser(description='Create scale variation systematics histograms.')
+
+parser.add_argument('input', metavar='input', nargs=1, help='The ROOT input file containing histograms')
+parser.add_argument('nominal', metavar='nominal', nargs=1, help='The name of the nominal histogram')
+
+args = parser.parse_args()
+
+import ROOT
+
+f = ROOT.TFile.Open(args.input[0])
+if not f:
+    sys.exit(1)
+
+nominal = f.Get(args.nominal[0])
+if not nominal:
+    print("%r not found in input file" % args.nominal[0])
+    sys.exit(1)
+
+scale_variations = []
+for x in range(0, 6):
+    scale_variations.append("%s__scale%d" % (args.nominal[0], x))
+
+# Check that all histograms are in the input root file
+for v in scale_variations:
+    h = f.Get(v)
+    if not h:
+        print("%r not found in input file" % v)
+        sys.exit(2)
+
+# All good, call the script doing the job
+
+args = ['./getEnvelopHistogram.py', '-i', '-s', 'scale', args.input[0], args.nominal[0]]
+args += scale_variations
+
+import subprocess
+subprocess.call(args)

--- a/scripts/getEnvelopHistogram.py
+++ b/scripts/getEnvelopHistogram.py
@@ -1,0 +1,92 @@
+#! /usr/bin/env python
+
+import ROOT
+import argparse
+import sys
+
+def getEnvelopHistograms(nominal, variations):
+    """
+    Compute envelop histograms create by all variations histograms. The envelop is simply the maximum
+    and minimum deviations from nominal for each bin of the distribution
+    """
+
+    if len(variations) < 2:
+        raise TypeError("At least two variations histograms must be provided")
+
+    n_bins = nominal.GetNbinsX()
+    for v in variations:
+        if v.GetNbinsX() != n_bins:
+            raise RuntimeError("Variation histograms do not have the same binning as the nominal histogram")
+
+    up = nominal.Clone()
+    up.SetDirectory(ROOT.nullptr)
+    up.Reset()
+
+    down = nominal.Clone()
+    down.SetDirectory(ROOT.nullptr)
+    down.Reset()
+
+    for i in range(1, n_bins + 1):
+        minimum = float("inf")
+        maximum = float("-inf")
+
+        for v in variations:
+            c = v.GetBinContent(i)
+            minimum = min(minimum, c)
+            maximum = max(maximum, c)
+
+        up.SetBinContent(i, maximum)
+        down.SetBinContent(i, minimum)
+
+    return (up, down)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Create an envelop histogram from a set of histograms.')
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-o', '--output', help='The ROOT output file')
+    group.add_argument('-i', '--in-place', action='store_true', help='If set, update the input ROOT file with the envelop histograms')
+    parser.add_argument('-s', '--suffix', default='', help='The suffix used to create the envelop histograms names')
+
+    parser.add_argument('input', metavar='input', nargs=1, help='The ROOT input file containing histograms')
+    parser.add_argument('nominal', metavar='nominal', nargs=1, help='The name of the nominal histogram')
+    parser.add_argument('variations', metavar='variation', nargs='+', help='The name of the variation histograms')
+
+    args = parser.parse_args()
+
+    input = ROOT.TFile.Open(args.input[0])
+    if not input:
+        sys.exit(1)
+
+    nominal = input.Get(args.nominal[0])
+    if not nominal:
+        sys.exit(1)
+    nominal.SetDirectory(ROOT.nullptr)
+
+    variations = []
+    for x in args.variations:
+        variations.append(input.Get(x))
+
+    up, down = getEnvelopHistograms(nominal, variations)
+    up.SetName(nominal.GetName() + "__%sup" % args.suffix)
+    down.SetName(nominal.GetName() + "__%sdown" % args.suffix)
+
+    if args.in_place:
+        # Re-open in UPDATE mode
+        input.Close()
+        input = ROOT.TFile.Open(args.input[0], "update")
+        up.Write('', ROOT.TObject.kOverwrite)
+        down.Write('', ROOT.TObject.kOverwrite)
+
+        print("%r and %r successfully added to %r" % (up.GetName(), down.GetName(), args.input[0]))
+    else:
+        output = ROOT.TFile.Open(args.output, "recreate")
+        nominal.Write()
+        up.Write()
+        down.Write()
+        output.Close()
+
+        print("%r and %r saved to %r" % (up.GetName(), down.GetName(), args.output))
+
+    input.Close()


### PR DESCRIPTION
There's two new scripts:
 - `getEnvelopHistogram.py`: a generic tool to compute an envelop from a set of histograms
 - `createScaleSystematics.py`: a wrapper around `getEnvelopHistogram.py` dedicated only to scale systematics.

Usage is easy:

```bash
./createScaleSystematics.py INPUT.root my_nominal_histogram
```

The script will look in `INPUT.root` for all the scale variations (**must** be named in this case `my_nominal_histogram__scale0`, `my_nominal_histogram__scale1`, ..., `my_nominal_histogram__scale5`), and create the envelop histograms, named in this case `my_nominal_histogram__scaleup` and `my_nominal_histogram__scaledown`. These histograms will be saved directly in the input file (so the content of the file is modified).

It gives this results (tested on a DY file borrowed from @AlexandreMertens). Black is nominal, red is scale up and green scale down:
![test_scale](https://cloud.githubusercontent.com/assets/386274/13081248/7697c134-d4cc-11e5-87f8-6ca8a62961fc.png)
