### PR TITLE
Include user code in the plotter itself

### DIFF
--- a/histFactory/templates/Plotter.cc.tpl
+++ b/histFactory/templates/Plotter.cc.tpl
@@ -33,6 +33,8 @@ TH1::SetDefaultSumw2(true);
 
 {{HISTS_DECLARATION}}
 
+{{USER_CODE_BEFORE_LOOP}}
+
     size_t index = 1;
     while (tree.next()) {
 
@@ -58,10 +60,14 @@ TH1::SetDefaultSumw2(true);
         bool __cut = false;
         double __weight = 0;
 
+{{USER_CODE_IN_LOOP}}
+
 {{PLOTS}}
 
         index++;
     }
+
+{{USER_CODE_AFTER_LOOP}}
 
     std::unique_ptr<TFile> outfile(TFile::Open(output_file.c_str(), "recreate"));
 


### PR DESCRIPTION
Add the possibility to insert user code in the plotter: before, inside, and after the loop over the events (e.g. to define variables used in the histograms, or load information from files, ...). 

This code is defined in the python configuration through the 3 **strings** "code_before_loop", "code_in_loop" and "code_after_loop". Of course, nothing prevents the user to retrieve this code from external files in the python code itself, if defining strings is impractical.

Also, slightly change the way C++ header files are included in the plotter (variable "includes" in the python file): if a headers contains a "<", ie is a library header (e.g. "<TH2.h>" instead of just "TH2.h"), no attempt is made to check the path to the header.