### PR TITLE
Port features to treeFactory

### DIFF
--- a/scripts/addHistos.py
+++ b/scripts/addHistos.py
@@ -1,5 +1,25 @@
 #! /usr/bin/env python
 
+# Written by Sebastien Wertz, 20/03/2016
+#
+# Combine histograms in output file and write resulting histograms to output file.
+#
+# Config file syntax example:
+#
+# toJoin = [
+#         {
+#             "match": "addThese_.*", "(and)*These",
+#             "newName": "result",
+#             "veto": "(not)?These",    # optional
+#             "normalise": True,    # optional
+#         }
+#     ]
+#
+# All histograms matching the regexp in "match" will be added to give the new histo with name "newName".
+# Histograms matching the "veto" regexp's will not be considered.
+# If asked, normalise the resulting histogram.
+
+
 import ROOT as R
 import argparse
 import imp

--- a/scripts/checkJobsAndResubmit.py
+++ b/scripts/checkJobsAndResubmit.py
@@ -1,6 +1,8 @@
+#!/usr/bin/env python
+
 import os, sys
 
-#usage from treefactory : python resubmit.py 'yourCondorDir' [submit]
+# Usage: resubmit.py 'yourCondorDir' [submit]
 
 condorDir = sys.argv[1]
 logDir = condorDir+"/logs/"

--- a/treeFactory/CMakeLists.txt
+++ b/treeFactory/CMakeLists.txt
@@ -30,7 +30,7 @@ if(NOT IN_CMSSW)
 endif()
 
 set(Boost_NO_BOOST_CMAKE ON)
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system filesystem)
 include_directories(${Boost_INCLUDE_DIRS})
 
 find_package(PythonLibs REQUIRED)
@@ -57,7 +57,7 @@ configure_file(scripts/createSkimmer.sh.in createSkimmer.sh @ONLY NEWLINE_STYLE 
 include(CP3Dictionaries)
 
 set(SKIMMER_SOURCES
-    "skimmer/createSkimmer.cc"
+    "src/createSkimmer.cc"
     "../common/src/formula_parser.cpp"
     )
 list(APPEND SKIMMER_SOURCES ${DICTIONARIES_SOURCES})
@@ -69,3 +69,5 @@ target_link_libraries(skimmer ${ROOT_LIBRARIES})
 target_link_libraries(skimmer ${PYTHON_LIBRARY})
 target_link_libraries(skimmer "uuid")
 target_link_libraries(skimmer ${CTEMPLATE_LIBS})
+target_link_libraries(skimmer ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY})

--- a/treeFactory/scripts/createSkimmer.sh.in
+++ b/treeFactory/scripts/createSkimmer.sh.in
@@ -26,7 +26,6 @@ mkdir -p "$OUTPUT/scripts"
 
 # Copy files
 cp -r "$COMMON_TOOLS_ROOT/cmake" "$OUTPUT"
-cp "$TEMPLATES_DIR/CMakeLists.txt" "$OUTPUT/"
 cp "$TEMPLATES_DIR/generateHeader.sh" "$OUTPUT/"
 cp -r "$COMMON_TOOLS_ROOT/common" "$OUTPUT"
 
@@ -41,7 +40,12 @@ cp "$PROJECT_DIR/scripts/parallelizedSkimmer.py.in" "$OUTPUT/scripts/"
 
 pushd "$OUTPUT/build" &> /dev/null
 
-cmake .. && make -j4
+command -v clang++ >/dev/null 2>&1
+if [[ $? -eq 0 ]]; then
+    CXX=clang++ cmake .. && make -j4
+else
+    cmake .. && make -j4
+fi
 
 popd &> /dev/null
 

--- a/treeFactory/templates/CMakeLists.txt.tpl
+++ b/treeFactory/templates/CMakeLists.txt.tpl
@@ -26,6 +26,7 @@ find_library(ROOT_GENVECTOR_LIB GenVector PATHS ${ROOT_LIBRARY_DIR}
 include_directories(${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(common/include)
+include_directories({{ADD_INCLUDES}})
 
 # Configure external
 set(EXTERNAL_DIR "${PROJECT_BINARY_DIR}/external")
@@ -42,6 +43,7 @@ set(SKIMMER_SOURCES
     Skimmer.cc
     ${EXTERNAL_SRC_DIR}/jsoncpp.cpp
     common/src/scale_factors.cpp
+    {{ADD_SOURCES}}
     )
 
 if(IN_CMSSW)

--- a/treeFactory/templates/Skimmer.cc.tpl
+++ b/treeFactory/templates/Skimmer.cc.tpl
@@ -19,6 +19,8 @@
 #include <json/json.h>
 #include <tclap/CmdLine.h>
 
+{{INCLUDES}}
+
 volatile bool MUST_STOP = false;
 
 void Skimmer::skim(const std::string& output_file) {
@@ -29,6 +31,8 @@ void Skimmer::skim(const std::string& output_file) {
     ROOT::TreeWrapper output_tree(output_tree_);
 
 {{OUTPUT_BRANCHES_DECLARATION}}
+
+{{USER_CODE_BEFORE_LOOP}}
 
     uint64_t selected_entries = 0;
     uint64_t index = 1;
@@ -51,6 +55,8 @@ void Skimmer::skim(const std::string& output_file) {
 
 {{GLOBAL_CUT}}
 
+{{USER_CODE_IN_LOOP}}
+
 {{OUTPUT_BRANCHES_FILLING}}
 
         output_tree.fill();
@@ -58,6 +64,9 @@ void Skimmer::skim(const std::string& output_file) {
         selected_entries++;
     }
 
+{{USER_CODE_AFTER_LOOP}}
+
+    outfile->cd();
     output_tree_->Write();
     outfile->Close();
 


### PR DESCRIPTION
* Port features added in #103 , #102 and #67 (allowing to include external files/code and extra branches in the plotter) to treeFactory.
* Move @BrieucF 's `resubmit.py` to a more suitable folder and rename it (it can be used for both plotter and skimmer).
* Make treeFactory's directory structure more similar to histFactory's one. And I'm thinking we could at some point move some of the common code to a ... common folder, since there is already some duplication.
* Also, it would be good if @BrieucF  or @OlivierBondu  could move the HH folder from treeFactory to their HH repo...