### PR TITLE
Custom output branch type

### DIFF
--- a/treeFactory/src/createSkimmer.cc
+++ b/treeFactory/src/createSkimmer.cc
@@ -49,7 +49,7 @@ struct OutputBranch {
     std::string name;
     std::string unique_name;
     std::string variable;
-
+    std::string type;
 };
 
 struct Tree {
@@ -88,6 +88,7 @@ struct UserCode {
 bool output_branch_from_PyObject(PyObject* value, OutputBranch& branch) {
     static PyObject* PY_NAME = PyString_FromString("name");
     static PyObject* PY_VARIABLE = PyString_FromString("variable");
+    static PyObject* PY_TYPE = PyString_FromString("type");
 
     if (! PyDict_Check(value)) {
         std::cerr << "Error: branches dictionnary value must be a dictionnary" << std::endl;
@@ -95,6 +96,8 @@ bool output_branch_from_PyObject(PyObject* value, OutputBranch& branch) {
 
     CHECK_AND_GET(branch.name, PY_NAME);
     CHECK_AND_GET(branch.variable, PY_VARIABLE);
+    branch.type = "float";
+    GET(branch.type, PY_TYPE);
 
     return true;
 }
@@ -478,7 +481,7 @@ bool execute(const std::string& skeleton, const std::string& config_file, std::s
         if (! parser.parse(b.variable, identifiers))
             std::cerr << "Warning: " << b.variable << " failed to parse." << std::endl;
 
-        output_branches_declaration += "    float& " + b.unique_name + " = output_tree[\"" + b.name + "\"].write<float>();\n";
+        output_branches_declaration += "    " + b.type + "& " + b.unique_name + " = output_tree[\"" + b.name + "\"].write<" + b.type + ">();\n";
         output_branches_filling += "        " + b.unique_name + " = (" + b.variable + ");\n";
     }
 

--- a/treeFactory/test/tree.py
+++ b/treeFactory/test/tree.py
@@ -1,3 +1,4 @@
+extra_branches = ["weight"]
 
 tree = {
         "name": "cool_tree",
@@ -9,13 +10,19 @@ tree = {
             {
                 "name": "branch_1",
                 "variable": "jet_p4[0].Pt()",
-                },
+            },
 
             {
                 "name": "weight_1",
                 "variable": "common::combineScaleFactors<2>({{{0.5, 0.5}, {0.7, 0.3}}}, common::Variation::NOMINAL)",
-                }
+            },
 
-            ]
+            {
+                "name": "is_data",
+                "variable": "is_data",
+                "type": "bool",
+            }
 
-        }
+        ]
+
+    }


### PR DESCRIPTION
treeFactory: add possibility to specify output branch type, using the field "type" in the python config, e.g.:
```
"branches": [
   {
      "name": "test",
      "variable": "is_data",
      "type": "bool",
   }
]
```
Maybe not very useful for a bool, but can be useful for storing e.g. LorentzVectors...