### PR TITLE
[HistFactory] add a way to store histograms in folders

### DIFF
--- a/histFactory/src/createPlotter.cpp
+++ b/histFactory/src/createPlotter.cpp
@@ -42,6 +42,7 @@ struct Plot {
     std::string weight;
     std::string binning;
     std::string normalize_to;
+    std::string output_root_folder;
 
     std::string title;
     std::string x_axis;
@@ -75,6 +76,7 @@ bool plot_from_PyObject(PyObject* value, Plot& plot) {
     static PyObject* PY_VARIABLE = PyString_FromString("variable");
     static PyObject* PY_PLOT_CUT = PyString_FromString("plot_cut");
     static PyObject* PY_NORMALIZE_TO = PyString_FromString("normalize-to");
+    static PyObject* PY_FOLDER = PyString_FromString("folder");
     static PyObject* PY_WEIGHT = PyString_FromString("weight");
     static PyObject* PY_BINNING = PyString_FromString("binning");
     static PyObject* PY_TITLE = PyString_FromString("title");
@@ -93,6 +95,9 @@ bool plot_from_PyObject(PyObject* value, Plot& plot) {
 
     plot.normalize_to = "nominal";
     GET(plot.normalize_to, PY_NORMALIZE_TO);
+
+    plot.output_root_folder = "";
+    GET(plot.output_root_folder, PY_FOLDER);
 
     plot.weight = "1.";
     GET(plot.weight, PY_WEIGHT);
@@ -495,6 +500,10 @@ bool execute(const std::string& skeleton, const std::string& config_file, std::s
 
         std::string sample_scale = "m_dataset.cross_section / m_dataset.extras_event_weight_sum[\"" + p.normalize_to + "\"]";
         save_plot.SetValue("SAMPLE_SCALE", sample_scale);
+        if (! p.output_root_folder.empty()) {
+            save_plot.ShowSection("IN_FOLDER");
+            save_plot.SetValue("FOLDER", p.output_root_folder);
+        }
         ctemplate::ExpandTemplate(getTemplate("SavePlot"), ctemplate::DO_NOT_STRIP, &save_plot, &text_save_plots);
     }
 

--- a/histFactory/templates/SavePlot.tpl
+++ b/histFactory/templates/SavePlot.tpl
@@ -1,5 +1,7 @@
     if (!m_dataset.is_data)
         {{UNIQUE_NAME}}->Scale({{SAMPLE_SCALE}});
+    {{#IN_FOLDER}}outfile->mkdir("{{FOLDER}}"); outfile->cd("{{FOLDER}}");{{/IN_FOLDER}}
     {{UNIQUE_NAME}}->SetName("{{PLOT_NAME}}");
     {{UNIQUE_NAME}}->Write("{{PLOT_NAME}}", TObject::kOverwrite);
+    {{#IN_FOLDER}}outfile->cd();{{/IN_FOLDER}}
 

--- a/histFactory/test/plots.py
+++ b/histFactory/test/plots.py
@@ -3,7 +3,8 @@ plots = [
             'name': 'test_1',
             'variable': 'electron_p4[0].Pt()',
             'plot_cut': 'electron_p4.size() > 0',
-            'binning': '(100, 0, 800)'
+            'binning': '(100, 0, 800)',
+            'folder': 'my/nice/little/folder'
         },
 
         {


### PR DESCRIPTION
An new option is available for the python configuration, `folder`, which specify in which folder the histogram must be saved. This option support multiple folders, separated with a `/`, like `my/folder`. If not specified, the histogram will be saved at the root of the file, as usual.