### PR TITLE
Add a way to split jobs per events instead of files

### DIFF
--- a/histFactory/templates/Plotter.h.tpl
+++ b/histFactory/templates/Plotter.h.tpl
@@ -79,6 +79,9 @@ struct Dataset {
     std::map<std::string, double> extras_event_weight_sum;
     bool is_data;
     std::string sample_weight_key;
+    uint64_t event_start = 0;
+    uint64_t event_end;
+    bool event_end_filled = false;
 };
 
 class Plotter {
@@ -90,6 +93,9 @@ class Plotter {
                     m_sample_cut = new TTreeFormula("sample_cut", dataset.cut.c_str(), ttree);
                     ttree->SetNotify(m_sample_cut);
                 }
+
+                tree.setEntry(dataset.event_start);
+                tree.stopAt(dataset.event_end);
             };
         virtual ~Plotter() { delete m_sample_cut; };
 

--- a/histFactory/test/plots.py
+++ b/histFactory/test/plots.py
@@ -5,7 +5,7 @@ plots = [
             'plot_cut': 'electron_p4.size() > 0',
             'binning': '(100, 0, 800)',
             'folder': 'my/nice/little/folder'
-        },
+            },
 
         {
             'name': 'test_normalize_to',
@@ -13,7 +13,14 @@ plots = [
             'plot_cut': 'electron_p4.size() > 0',
             'binning': '(100, 0, 800)',
             "normalize-to": "pdf_up"
-        },
+            },
+
+        {
+            'name': 'entries',
+            'variable': '1',
+            'binning': '(2, 0, 2)',
+            'plot_cut': 'true'
+            }
 
         ]
 

--- a/histFactory/test/sample.json
+++ b/histFactory/test/sample.json
@@ -2,13 +2,15 @@
     "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2_v1.0.0+7415_TTAnalysis_12d3865": {
         "tree_name": "t",
         "files": [
-            "/storage/data/cms/store/user/sbrochet/TT_TuneCUETP8M1_13TeV-powheg-pythia8/TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2/151021_071654/0000/output_mc_1.root"
+            "/storage/data/cms/store/user/obondu/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/TTJets_TuneCUETP8M1_amcatnloFXFX_25ns/160706_112558/0000/output_mc_1.root"
         ],
-        "db_name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2_v1.0.0+7415_TTAnalysis_12d3865",
+        "db_name": "TTJets_TuneCUETP8M1_amcatnloFXFX_25ns_v0.1.4+76X_HHAnalysis_2016-06-03.v0",
         "sample_cut": "1.",
         "sample-weight": "test",
         "extras-event-weight-sum": {
-        "pdf_up": 1000
-        }
+            "pdf_up": 1000
+        },
+        "event-start": 10,
+        "event-end": 1000
     }
 }

--- a/treeFactory/templates/Skimmer.cc.tpl
+++ b/treeFactory/templates/Skimmer.cc.tpl
@@ -41,6 +41,7 @@ void Skimmer::skim(const std::string& output_file) {
 {{USER_CODE_BEFORE_LOOP}}
 
     uint64_t selected_entries = 0;
+    uint64_t entries = m_dataset.event_end - m_dataset.event_start + 1;
     uint64_t index = 1;
     while (tree.next()) {
 
@@ -49,7 +50,7 @@ void Skimmer::skim(const std::string& output_file) {
         }
 
         if ((index - 1) % 1000 == 0)
-            std::cout << "Processing entry " << index << " of " << tree.getEntries() << std::endl;
+            std::cout << "Processing entry " << index << " of " << entries << std::endl;
         index++;
         
         if (m_sample_cut){
@@ -143,6 +144,24 @@ bool parse_datasets(const std::string& json_file, std::vector<Dataset>& datasets
             dataset.files.push_back(dataset.path + "/*.root");
         }
 
+        // Read where to start and end the process loop
+        if (sample.isMember("event-start")) {
+            dataset.event_start = sample["event-start"].asUInt64();
+        } else {
+            dataset.event_start = 0;
+        }
+
+        if (sample.isMember("event-end")) {
+            dataset.event_end = sample["event-end"].asUInt64();
+            dataset.event_end_filled = true;
+        } else {
+            dataset.event_end = 0;
+        }
+
+        if (dataset.event_end_filled && dataset.event_end < dataset.event_start)
+            dataset.event_end_filled = false;
+
+
         datasets.push_back(dataset);
     }
 
@@ -209,7 +228,7 @@ int main(int argc, char** argv) {
             return false;
         };
 
-        for (const Dataset& d: datasets) {
+        for (Dataset& d: datasets) {
             if (MUST_STOP)
                 break;
 
@@ -230,6 +249,17 @@ int main(int argc, char** argv) {
             t->SetCacheSize(10 * 1024 * 1024);
             // Learn tree structure from the first 10 entries
             t->SetCacheLearnEntries(10);
+
+            if (!d.event_end_filled) {
+                // Process everything
+                d.event_end = t->GetEntries() - 1;
+                d.event_end_filled = true;
+            } else if (d.event_end >= t->GetEntries()) {
+                d.event_end = t->GetEntries() - 1;
+            }
+
+            std::cout << "Processing events " << d.event_start << " to " << d.event_end << std::endl;
+
 
             Skimmer s(d, wrapped_tree, t.get());
             s.skim(output_file);

--- a/treeFactory/templates/Skimmer.h.tpl
+++ b/treeFactory/templates/Skimmer.h.tpl
@@ -38,6 +38,9 @@ struct Dataset {
     std::vector<std::string> files;
     std::string cut;
     std::string sample_weight_key;
+    uint64_t event_start = 0;
+    uint64_t event_end;
+    bool event_end_filled = false;
 };
 
 class Skimmer {
@@ -48,6 +51,9 @@ class Skimmer {
                     m_sample_cut = new TTreeFormula("sample_cut", dataset.cut.c_str(), raw_tree);
                     raw_tree->SetNotify(m_sample_cut);
                 }
+                
+                tree.setEntry(dataset.event_start);
+                tree.stopAt(dataset.event_end);
             }
         virtual ~Skimmer() {};
 


### PR DESCRIPTION
PR is in two parts:

  1. Add necessary code into histFactory / treeFactory to handle starting and ending entry for the event loop
  2. Add a new option in condor tools, `events_per_jobs`.

It's probably possible to do the same thing smartly, but at least it's working :) I tested it with histFactory doing a plot splitting either per files or per events, and I got exactly the same histograms :+1: 

Note that this PR depends on a updated version of TreeWrapper: https://github.com/blinkseb/TreeWrapper/commit/f15829c381c14f48edd98aed47979d427ce8ac28