### PR TITLE
Small fixes; fix use outside of CMSSW

### DIFF
--- a/Factories/README.md
+++ b/Factories/README.md
@@ -54,6 +54,10 @@ An helper script is available to create a viable working directory for the plott
 ./createPlotter.sh <skeleton ROOT file> <python configuration file> <output directory>
 ```
 
+**Note**: Outside of CMSSW, you need to have [TreeWrapper](https://github.com/blinkseb/TreeWrapper) installed somewhere (say in `TW`). Then, to be able to build the generated code (or run `createPlotter.sh`), you'll need the following environment variables to be set:
+ - `CMAKE_LIBRARY_PATH` to `$TW/.libs`
+ - `CMAKE_INCLUDE_PATH` to `$TW/interface`
+
 3 arguments are needed:
  1) `skeleton ROOT file`: The absolute path of a ROOT file from one of your datasets. It's needed because of code creating the plotting code needs to know the structure of the tree to correctly identify what is a branch in your plot / cut strings. This can be *any* file from *any* dataset, it really does not matter: you just have to ensure that the tree structure is correct.
 
@@ -117,3 +121,22 @@ The value of the `branches` key is a list of dictionaries. Each dictionary descr
  - `name`: the name of the branch
  - `variable`: the formula used to evaluate the branch value.
  - `type`: the type of the branch. Default to `float`
+
+
+### JSON file format
+
+The entries in the JSON file passed to either `plotter.exe` or `skimmer.exe` can have the following fields:
+ - `is-data` (default to `False`): specifies if the sample is data or not. No event weight is applied in the former case
+ - `sample_cut` (default to `1`): apply cut on the whole sample
+ - `tree_name` (default to `t`): name of the TTree from which to read the data
+ - `db_name` (defaults to the sample name): name of the sample in the DB.
+ - `output_name` (defaults to the `db_name`): "base" name of the output file
+ - `suffix` (default to `_histos` for HistFactory, and `_skim` for TreeFactory): suffix appended to the "base" output name
+ - `cross-section` (default to `1`): stored as TParameter in the output file
+ - `event-weight-sum` (default to `1`): stored as TParameter in the output file. In HistFactory, histograms are scaled by `cross-section/event-weight-sum`
+ - `extras-event-weight-sum` (optional): Dictionary of extra event weight sums to use (for systematics, for instance). By default the only key is `"nominal"`, with value `event-weight-sum`
+ - `sample-weight` (optional): Name of the special per-event sample weight to be used (see above, Python file format)
+ - `files`: List of files as input, or:
+ - `path`: Take all `.root` files in this directory
+ - `event-start` (default `0`): first event to be read
+ - `event-end` (default last): last event to be read

--- a/Factories/scripts/createFactory.sh.in
+++ b/Factories/scripts/createFactory.sh.in
@@ -46,12 +46,16 @@ cp "$PROJECT_DIR/scripts/parallelizedFactory.py.in" "$OUTPUT/scripts/"
 
 pushd "$OUTPUT/build" &> /dev/null
 
+
+set +e
+chosen_CXX=""
 command -v clang++ >/dev/null 2>&1
 if [[ $? -eq 0 ]]; then
-    CXX=clang++ cmake .. && make -j4
-else
-    cmake .. && make -j4
+    chosen_CXX="clang++"
 fi
+set -e
+
+CXX=${chosen_CXX} cmake .. && make -j 4
 
 popd &> /dev/null
 

--- a/Factories/src/HistFactory.cc
+++ b/Factories/src/HistFactory.cc
@@ -21,9 +21,11 @@ bool plot_from_PyObject(PyObject* value, Plot& plot) {
 
     CHECK_AND_GET(plot.name, PY_NAME);
     CHECK_AND_GET(plot.variable, PY_VARIABLE);
-    CHECK_AND_GET(plot.cut, PY_PLOT_CUT);
     CHECK_AND_GET(plot.binning, PY_BINNING);
 
+    plot.cut = "1";
+    GET(plot.cut, PY_PLOT_CUT);
+    
     plot.normalize_to = "nominal";
     GET(plot.normalize_to, PY_NORMALIZE_TO);
 

--- a/Factories/templates/CMakeLists.txt.tpl
+++ b/Factories/templates/CMakeLists.txt.tpl
@@ -62,10 +62,14 @@ if(IN_CMSSW)
             ${PROJECT_SOURCE_DIR}/generateHeader.sh
             ${PROJECT_BINARY_DIR}/classes.h
             COMMENT "Generating classes.h...")
-
+    add_definitions(-DIN_CMSSW)
+    find_library(TREEWRAPPER_LIB cp3_llbbTreeWrapper PATHS
+        "$ENV{CMSSW_BASE}/lib/$ENV{SCRAM_ARCH}" NO_DEFAULT_PATH)
+    list(APPEND SOURCES classes.h)
+else()
+    find_library(TREEWRAPPER_LIB TreeWrapper)
+    find_path(TREEWRAPPER_INCLUDE_DIR TreeWrapper.h)
 endif()
-
-list(APPEND SOURCES classes.h)
 
 add_executable(generated ${SOURCES})
 set_target_properties(generated PROPERTIES OUTPUT_NAME "{{EXECUTABLE}}")
@@ -76,9 +80,10 @@ target_link_libraries(generated ${ROOT_GENVECTOR_LIB})
 target_link_libraries(generated ${ROOT_TMVA_LIBRARY})
 target_link_libraries(generated ${ROOT_TREEPLAYER_LIB})
 
-find_library(TREEWRAPPER_LIB cp3_llbbTreeWrapper PATHS
-    "$ENV{CMSSW_BASE}/lib/$ENV{SCRAM_ARCH}" NO_DEFAULT_PATH)
 target_link_libraries(generated ${TREEWRAPPER_LIB})
+if(NOT IN_CMSSW)
+    target_include_directories(generated PRIVATE ${TREEWRAPPER_INCLUDE_DIR})
+endif()
 
 # Find libraries requested by the user, if any
 {{#HAS_LIBRARY_DIRECTORIES}}

--- a/Factories/templates/Main.cc.tpl
+++ b/Factories/templates/Main.cc.tpl
@@ -108,19 +108,21 @@ bool parse_datasets(const std::string& json_file, std::vector<Dataset>& datasets
         const Json::Value& sample = root[samples_str[index]];
         Dataset dataset;
 
-        // Mandatory fields
         dataset.name = samples_str[index];
-        dataset.db_name = sample["db_name"].asString();
+        
+        dataset.is_data = sample.get("is-data", false).asBool();
         dataset.cut = sample.get("sample_cut", "1").asString();
         dataset.tree_name = sample.get("tree_name", "t").asString();
-        dataset.is_data = sample["is-data"].asBool();
 
+        dataset.db_name = sample.get("db_name", dataset.name).asString();
         if (sample.isMember("output_name")) {
             dataset.output_name = sample["output_name"].asString();
         } else {
-            dataset.output_name = dataset.db_name + "_{{SUFFIX}}";
+            dataset.output_name = dataset.db_name;
             if(sample.isMember("suffix"))
                 dataset.output_name += sample["suffix"].asString();
+            else
+                dataset.output_name += "_{{SUFFIX}}";
         }
         
         if( std::find_if(datasets.begin(), datasets.end(), [&](const Dataset &d){ return d.output_name == dataset.output_name; }) != datasets.end() ){

--- a/Factories/templates/Main.h.tpl
+++ b/Factories/templates/Main.h.tpl
@@ -17,10 +17,12 @@
 #include <TTreeFormula.h>
 #include <Math/Vector4D.h>
 
-// Generated automatically
-#include <classes.h>
-
-#include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
+#ifdef IN_CMSSW
+    #include <classes.h> // Generated automatically
+    #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
+#else
+    #include <TreeWrapper.h>
+#endif
 
 // No other choices, as ROOT strips the 'std' namespace from types...
 using namespace std;


### PR DESCRIPTION
Small fixes:
-The field `plot_cut` in the `plots` variable in the python config had become mandatory when it shouldn't be
- The fields `is-data` and `db-name` in the sample JSONS do not have to be mandatory

It's now possible to use HistFactory and TreeFactory completely outside of CMSSW. Only thing that is needed is Seb's `TreeWrapper` library, and some tweaks to link to the latter when running `createPlotter` (see README).