### PR TITLE
Add a way to clone the input tree when skimming

### DIFF
--- a/Factories/include/Factory.h
+++ b/Factories/include/Factory.h
@@ -76,6 +76,7 @@ class Factory {
 
         virtual std::string name() const = 0;
         virtual std::string suffix() const = 0;
+        virtual bool read_whole_tree() const { return false; }
 
         virtual bool parse_config_file(PyObject* global_dict) = 0;
         virtual bool create_templates(std::set<std::string>& identifiers, std::string& beforeLoop, std::string& inLoop, std::string& afterLoop) = 0;

--- a/Factories/include/TreeFactory.h
+++ b/Factories/include/TreeFactory.h
@@ -14,6 +14,7 @@ struct OutputBranch {
 struct Tree {
     std::string name;
     std::string cut;
+    bool clone;
     std::vector<OutputBranch> branches;
 };
 
@@ -27,6 +28,10 @@ protected:
 
     virtual std::string suffix() const override {
         return "skim";
+    }
+
+    virtual bool read_whole_tree() const override {
+        return m_tree.clone;
     }
 
     virtual bool parse_config_file(PyObject* global_dict) override;

--- a/Factories/src/Factory.cc
+++ b/Factories/src/Factory.cc
@@ -354,6 +354,8 @@ bool Factory::run() {
 
     sample_weight_function += "\n    return 1.;";
 
+    std::string tree_read_all =  read_whole_tree() ? "true" : "false";
+
     std::string output;
 
     // Main source file
@@ -368,6 +370,7 @@ bool Factory::run() {
     source.SetValue("CODE_BEFORE_LOOP", beforeLoop);
     source.SetValue("CODE_IN_LOOP", inLoop);
     source.SetValue("CODE_AFTER_LOOP", afterLoop);
+    source.SetValue("TREE_READ_ALL", tree_read_all);
 
     ctemplate::ExpandTemplate(get_template("Main.cc"), ctemplate::DO_NOT_STRIP, &source, &output);
 

--- a/Factories/src/HistFactory.cc
+++ b/Factories/src/HistFactory.cc
@@ -172,6 +172,11 @@ bool HistFactory::create_templates(std::set<std::string>& identifiers, std::stri
     std::unique_ptr<TFile> outfile(TFile::Open(output_file.c_str(), "recreate"));
 )";
 
+    afterLoop += R"(
+    outfile->cd();
+
+)";
+
     for (auto& p: m_plots) {
         ctemplate::TemplateDictionary save_plot("save_plot");
         save_plot.SetValue("UNIQUE_NAME", p.unique_name);

--- a/Factories/templates/Main.cc.tpl
+++ b/Factories/templates/Main.cc.tpl
@@ -38,7 +38,7 @@ void {{CLASS_NAME}}::work(const std::string& output_file) {
 
     uint64_t entries = m_dataset.event_end - m_dataset.event_start + 1;
     size_t index = 1;
-    while (tree.next()) {
+    while (tree.next({{TREE_READ_ALL}})) {
 
         if (MUST_STOP) {
             break;

--- a/Factories/test/sample.json
+++ b/Factories/test/sample.json
@@ -1,16 +1,14 @@
 {
-    "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2_v1.0.0+7415_TTAnalysis_12d3865": {
+    "TTTo2L2Nu_13TeV-powheg_ext1_Spring16MiniAODv2_v0.1.1+76X-75-g45bc215_HHAnalysis_2016-06-03.v0-38-gd217142": {
         "tree_name": "t",
         "files": [
-            "/storage/data/cms/store/user/obondu/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/TTJets_TuneCUETP8M1_amcatnloFXFX_25ns/160706_112558/0000/output_mc_1.root"
+            "/storage/data/cms/store/user/sbrochet/TTTo2L2Nu_13TeV-powheg/TTTo2L2Nu_13TeV-powheg_ext1_Spring16MiniAODv2/161120_001605/0000/output_mc_757.root"
         ],
-        "db_name": "TTJets_TuneCUETP8M1_amcatnloFXFX_25ns_v0.1.4+76X_HHAnalysis_2016-06-03.v0",
+        "db_name": "TTTo2L2Nu_13TeV-powheg_ext1_Spring16MiniAODv2_v0.1.1+76X-75-g45bc215_HHAnalysis_2016-06-03.v0-38-gd217142",
         "sample_cut": "1.",
         "sample-weight": "test",
         "extras-event-weight-sum": {
             "pdf_up": 1000
-        },
-        "event-start": 10,
-        "event-end": 1000
+        }
     }
 }

--- a/Factories/test/tree.py
+++ b/Factories/test/tree.py
@@ -3,6 +3,8 @@ extra_branches = ["weight"]
 tree = {
         "name": "cool_tree",
 
+        "clone": True,
+
         "cut": "!(jet_p4[0].Pt() < 20)",
 
         "branches": [


### PR DESCRIPTION
Useful to simply add branches into an existing tree while applying a set of cuts. Simply turn the flag `clone` in the `tree` dict to enable this feature.

Second commit is unrelated but fix an issue in histFactory mode