### PR TITLE
Build TreeWrapper as external even within CMSSW

### DIFF
--- a/Factories/cmake/modules/BuildExternals.cmake
+++ b/Factories/cmake/modules/BuildExternals.cmake
@@ -11,6 +11,7 @@ set(CTEMPLATE_VERSION "2.3")
 set(CTEMPLATE_TAR "ctemplate-${CTEMPLATE_VERSION}.tar.gz")
 set(CTEMPLATE_DIR ${EXTERNAL_DIR}/ctemplate-ctemplate-${CTEMPLATE_VERSION})
 
+set(TREEWRAPPER_DIR ${EXTERNAL_DIR}/TreeWrapper)
 
 if (NOT EXTERNAL_BUILT)
 
@@ -29,9 +30,14 @@ if (NOT EXTERNAL_BUILT)
     MESSAGE(STATUS "Building ctemplate")
     execute_process(COMMAND curl -L "https://github.com/OlafvdSpek/ctemplate/archive/ctemplate-${CTEMPLATE_VERSION}.tar.gz" -o "${CTEMPLATE_TAR}" WORKING_DIRECTORY ${EXTERNAL_DIR})
     execute_process(COMMAND tar xf ${CTEMPLATE_TAR} WORKING_DIRECTORY ${EXTERNAL_DIR})
-    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} WORKING_DIRECTORY ${CTEMPLATE_DIR})
-    execute_process(COMMAND make -j10 WORKING_DIRECTORY ${CTEMPLATE_DIR})
+    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} --enable-shared=false WORKING_DIRECTORY ${CTEMPLATE_DIR})
     execute_process(COMMAND make install -j10 WORKING_DIRECTORY ${CTEMPLATE_DIR})
+
+    message(STATUS "Building TreeWrapper")
+    execute_process(COMMAND git clone https://github.com/blinkseb/TreeWrapper.git WORKING_DIRECTORY ${EXTERNAL_DIR})
+    execute_process(COMMAND ./autogen.sh WORKING_DIRECTORY ${TREEWRAPPER_DIR})
+    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} --with-boost=${Boost_INCLUDE_DIRS} --enable-shared=false WORKING_DIRECTORY ${TREEWRAPPER_DIR})
+    execute_process(COMMAND make install -j10 WORKING_DIRECTORY ${TREEWRAPPER_DIR})
 
     set(EXTERNAL_BUILT ON CACHE BOOL "Are externals already built?")
 endif()

--- a/Factories/templates/CMakeLists.txt.tpl
+++ b/Factories/templates/CMakeLists.txt.tpl
@@ -63,13 +63,11 @@ if(IN_CMSSW)
             ${PROJECT_BINARY_DIR}/classes.h
             COMMENT "Generating classes.h...")
     add_definitions(-DIN_CMSSW)
-    find_library(TREEWRAPPER_LIB cp3_llbbTreeWrapper PATHS
-        "$ENV{CMSSW_BASE}/lib/$ENV{SCRAM_ARCH}" NO_DEFAULT_PATH)
     list(APPEND SOURCES classes.h)
-else()
-    find_library(TREEWRAPPER_LIB TreeWrapper)
-    find_path(TREEWRAPPER_INCLUDE_DIR TreeWrapper.h)
 endif()
+
+find_library(TREEWRAPPER_LIB "libTreeWrapper.a" PATHS ${EXTERNAL_LIB_DIR})
+find_path(TREEWRAPPER_INCLUDE_DIR TreeWrapper.h PATHS ${EXTERNAL_INCLUDE_DIR})
 
 add_executable(generated ${SOURCES})
 set_target_properties(generated PROPERTIES OUTPUT_NAME "{{EXECUTABLE}}")

--- a/Factories/templates/Main.h.tpl
+++ b/Factories/templates/Main.h.tpl
@@ -19,10 +19,9 @@
 
 #ifdef IN_CMSSW
     #include <classes.h> // Generated automatically
-    #include <cp3_llbb/TreeWrapper/interface/TreeWrapper.h>
-#else
-    #include <TreeWrapper.h>
 #endif
+
+#include <TreeWrapper.h>
 
 // No other choices, as ROOT strips the 'std' namespace from types...
 using namespace std;


### PR DESCRIPTION
This PR decouples again a bit more `Factories` from CMSSW by always building TreeWrapper as an external dependency, even within CMSSW. The mid-term vision here is to be able to build the plotter / skimmer with a different version of ROOT than the one shipped with CMSSW and for that, one has to be sure that all the libraries are built against the same version of ROOT, which is not the case if we use the TreeWrapper built within CMSSW.