### PR TITLE
Flatten variable; ratio plots for graphs

### DIFF
--- a/scripts/flattenDistribution.py
+++ b/scripts/flattenDistribution.py
@@ -1,0 +1,116 @@
+#! /usr/bin/env python
+
+import argparse
+import ROOT as R
+from array import array
+
+parser = argparse.ArgumentParser(description="For a given variable, find bin limits needed to build a flat distribution.")
+parser.add_argument('-i', '--input', nargs='+', help='Input files containing TTrees', required=True)
+parser.add_argument('-c', '--cut', help='Formula to cut on events', default="1")
+parser.add_argument('-v', '--variable', help='Branch for the variable to be flattened', required=True)
+parser.add_argument('-w', '--weight', help='Branch for the event weight', default="1")
+parser.add_argument('-n', '--nbins', type=int, help='Number of bins desired', required=True)
+parser.add_argument('-o', '--output', help='Output file containing validation histogram', default="test.root")
+
+args = parser.parse_args()
+
+value_list = []
+weight_sum = 0.
+
+for file in args.input:
+    print("Working on " + file)
+
+    tfile = R.TFile.Open(file)
+    tree = tfile.Get("t")
+
+    try:
+        xs = tfile.Get("cross_section").GetVal()
+        wgt_sum = tfile.Get("event_weight_sum").GetVal()
+        print "Found XS = {}, event weight sum = {}".format(xs, wgt_sum)
+    except AttributeError:
+        xs = 1.
+        wgt_sum = 1.
+        print "Did not find XS or event weight sum info, will use 1."
+
+    if args.cut != "1":
+        cut = R.TTreeFormula("cut", args.cut, tree)
+    else:
+        cut = None
+
+    for event in tree:
+        if cut is not None and not cut.EvalInstance():
+            continue
+
+        weight = tree.__getattr__(args.weight) if args.weight is not "1" else 1.
+        weight *= xs / wgt_sum
+        var = tree.__getattr__(args.variable)
+        value_list.append( [var, weight] )
+        weight_sum += weight
+
+    tfile.Close()
+
+print "Sorting values..."
+value_list.sort(key=lambda x: x[0])
+
+# Careful to avoid having twice the same values (can happen a lot for e.g. BDTs)!
+# In those cases the algorithm for bin limits will not work
+# => Remove duplicates but keep their weights
+print "Removing duplicates..."
+new_value_list = []
+for i, entry in enumerate(value_list):
+    if i > 0 and new_value_list[-1][0] == entry[0]:
+        new_value_list[-1][1] += entry[1]
+        continue
+    new_value_list.append(entry[:])
+print "Found {} duplicates!".format(len(value_list) - len(new_value_list))
+
+bin_limits = [ new_value_list[0][0] ]
+current_bin = new_value_list[0][1]
+
+weight_avg = weight_sum/len(value_list)
+ratio = (weight_sum) / args.nbins
+print "Finding bin edges..."
+print "Target weight per bin: ", ratio
+print "Avg. event weight: ", weight_avg
+print "Total event weight: ", weight_sum
+print "Total event count, duplicates removed: ", len(value_list)
+
+print "Starting bin edge: ", new_value_list[0][0]
+for i, entry in enumerate(new_value_list):
+    if current_bin >= ratio and i != 0:
+        slope = new_value_list[i-1][1] / ( entry[0] - new_value_list[i-1][0] )
+        next_value = new_value_list[i-1][0] + (ratio - current_bin + new_value_list[i-1][1]) / slope
+        bin_limits.append(next_value)
+        print "Adding bin: {}".format(next_value)
+        print "Current sum of weights: ", current_bin
+        print "Previous sum of weights: ", current_bin - entry[1]
+        # We have to be careful: the weight in the next bin is not the weight of the first event in it,
+        # it has to be corrected for the fact that the bin limit found is between two events
+        current_bin = slope*(entry[0] - next_value)
+    current_bin += entry[1]
+    if len(bin_limits) == args.nbins:
+        print "Last bin reached."
+        print "Remaining sum of weights: ", sum([ val[1] for val in new_value_list[i:-1]])
+        print "Adding bin: {}".format(new_value_list[-1][0])
+        bin_limits.append(new_value_list[-1][0])
+        break
+
+print "Bin limits:"
+print bin_limits
+
+print "Filling validation histograms..."
+out_file = R.TFile(args.output, "recreate")
+
+# Fill with all the actual events read
+testHisto = R.TH1F(args.variable, "", len(bin_limits) - 1, array('f', bin_limits))
+for entry in value_list:
+    testHisto.Fill(entry[0], entry[1])
+testHisto.Write()
+
+# Fill with duplicates removed & corrected weights
+testHistoDupl = R.TH1F(args.variable + "_dupl", "", len(bin_limits) - 1, array('f', bin_limits))
+for entry in new_value_list:
+    testHistoDupl.Fill(entry[0], entry[1])
+testHistoDupl.Write()
+
+out_file.Close()

--- a/toolBox/drawCanvas.py
+++ b/toolBox/drawCanvas.py
@@ -1,57 +1,184 @@
 import ROOT
+import os
+from math import sqrt
 
 def printCanvas(canvas, name, formats, directory):
-    for format in formats : 
-        outFile=directory+"/"+name+"."+format
+    for format in formats:
+        outFile = os.path.join(directory, name + "." + format)
         canvas.Print(outFile)
 
-def drawTGraph(graphs, name, xlabel, ylabel, legend, leftText, rightText, formats, directory, range=None, log_range=None):
-    canvas=ROOT.TCanvas(name,name, 550, 400)
-    canvas.SetGridx()
-    canvas.SetGridy()
-    Tleft=ROOT.TLatex(0.125,0.92,leftText)
+
+def createRatioFromGraph(num, denom):
+    """Build and return a ratio graph from two TGraphError objects.
+    Assumes the two objects have points at the same abscissas."""
+
+    n = num.GetN()
+    assert(n == denom.GetN())
+
+    x_list = []
+    ratio_list = []
+    ratio_list_err = []
+    
+    th1_num = ROOT.TH1F("temp_num", "temp", n+1, 0, 1)
+    th1_num.SetDirectory(0)
+    th1_num.Sumw2()
+    th1_denom = ROOT.TH1F("temp_denom", "temp", n+1, 0, 1)
+    th1_denom.SetDirectory(0)
+    th1_denom.Sumw2()
+    
+    for i in xrange(n):
+        x = ROOT.Double()
+        
+        num_y = ROOT.Double()
+        num.GetPoint(i, x, num_y)
+        num_err = num.GetErrorY(i)
+        th1_num.SetBinContent(i+1, num_y)
+        th1_num.SetBinError(i+1, num_err)
+        
+        denom_y = ROOT.Double()
+        denom.GetPoint(i, x, denom_y)
+        denom_err = denom.GetErrorY(i)
+        th1_denom.SetBinContent(i+1, denom_y)
+        th1_denom.SetBinError(i+1, denom_err)
+
+    th1_num.Divide(th1_denom)
+
+    ratio = ROOT.TGraphAsymmErrors(n)
+
+    for i in xrange(n):
+        x = ROOT.Double()
+        y = ROOT.Double()
+        num.GetPoint(i, x, num_y)
+        
+        ratio.SetPoint(i, x, th1_num.GetBinContent(i+1))
+        ratio.SetPointError(i, 0, 0, th1_num.GetBinErrorLow(i+1), th1_num.GetBinErrorUp(i+1))
+
+    ratio.SetMarkerColor(1)
+    ratio.SetMarkerSize(0.6)
+    ratio.SetMarkerStyle(20)
+
+    return ratio
+
+
+def getGraphMinMax(graph):
+    """Return the mininmum and maximum ordinate values of a TGraph."""
+
+    x = ROOT.Double()
+    y = ROOT.Double()
+    graph.GetPoint(0, x, y)
+    min = float(y)
+    max = float(y)
+    for i in xrange(1, graph.GetN()):
+        graph.GetPoint(i, x, y)
+        if y > max:
+            max = float(y)
+        if y < min:
+            min = float(y)
+    return min, max        
+
+
+def drawTGraph(graphs, name, xLabel="", yLabel="", legend=None, leftText="", rightText="", formats=["pdf"], dir=".", style="P", range=None, doLogX=False, logRange=None, ratio=None):
+    """Draw and print a set of TGraphs on a canvas."""
+
+    gStyle()
+
+    pads = {}
+
+    if ratio is not None:
+        pads["canvas"] = ROOT.TCanvas(name, name, 550, 450)
+        pads["base"] = ROOT.TPad("base", "", 0, 0, 1, 1)
+        pads["base"].Draw()
+        pads["base"].cd()
+        pads["hist"] = ROOT.TPad("hist", name, 0, 0.2, 1, 1)
+    else:
+        pads["canvas"] = ROOT.TCanvas(name, name, 550, 400)
+        pads["base"] = ROOT.TPad("base", "", 0, 0, 1, 1)
+        pads["base"].Draw()
+        pads["base"].cd()
+        pads["hist"] = ROOT.TPad("hist", name, 0, 0, 1, 1)
+    pads["hist"].SetGrid()
+    pads["hist"].Draw()
+    pads["hist"].cd()
+    
+    Tleft = ROOT.TLatex(0.125, 0.92, leftText)
     Tleft.SetNDC(ROOT.kTRUE) 
     Tleft.SetTextSize(0.048)
-    #font = Tleft.GetTextFont() 
-    #TPaveText* Tright=new TPaveText(0.8,0.85,0.945,0.90,"NDC") 
-    #Tright.SetTextFont(font) 
-    #Tright.AddText(rightText) 
-    #Tright.SetFillColor(0)
+    font = Tleft.GetTextFont() 
+    Tright = ROOT.TLatex(0.8, 0.85, rightText) 
+    Tright.SetNDC(ROOT.kTRUE) 
+    Tright.SetTextSize(0.048)
+    Tright.SetTextFont(font) 
 
     mg = ROOT.TMultiGraph()
-    colors = [ ROOT.kRed, ROOT.kMagenta, ROOT.kBlue, ROOT.kCyan+1, ROOT.kGreen+2, ROOT.kOrange+1 ]
+    colors = [ ROOT.kRed, ROOT.kBlue, ROOT.kMagenta, ROOT.kCyan+1, ROOT.kGreen+2, ROOT.kOrange+1 ]
     markers = [20, 21, 22, 23, 29, 33, 34]
-    for i,graph in enumerate(graphs):
+    
+    for i, graph in enumerate(graphs):
         graph.SetMarkerColor(colors[i])
         graph.SetLineColor(colors[i])
         graph.SetLineWidth(2)
         graph.SetMarkerStyle(markers[i])
         mg.Add(graph)
-    mg.Draw("AL")
-    mg.GetXaxis().SetTitle(xlabel)
-    #mg.GetXaxis().SetTitleFont(font)
+    
+    mg.Draw("A" + style)
+    mg.GetXaxis().SetTitle(xLabel)
+    mg.GetXaxis().SetTitleFont(font)
     if range:
         mg.GetXaxis().SetRangeUser(range[0][0], range[0][1])
         mg.GetYaxis().SetRangeUser(range[1][0], range[1][1])
-    mg.GetYaxis().SetTitle(ylabel)
-    #mg.GetYaxis().SetTitleFont(font)
+    mg.GetYaxis().SetTitle(yLabel)
+    mg.GetYaxis().SetTitleFont(font)
     mg.SetTitle("")
-    #legend.SetTextFont(font) 
-    legend.SetFillColor(10)
-    legend.SetFillStyle(0)
-    legend.SetLineColor(0)
-    legend.SetTextSize(0.035)
-    legend.Draw() 
-    Tleft.Draw() 
-    #Tright.Draw() 
-    #canvas.Write() 
-    printCanvas(canvas, name, formats, directory) 
-    if log_range:
-        mg.GetXaxis().SetRangeUser(log_range[0][0], log_range[0][1])
-        mg.GetYaxis().SetRangeUser(log_range[1][0], log_range[1][1])
+    
+    if legend is not None:
+        legend.SetTextFont(font) 
+        legend.SetFillColor(10)
+        legend.SetFillStyle(0)
+        legend.SetLineColor(0)
+        legend.SetTextSize(0.035)
+        legend.Draw() 
 
-    canvas.SetLogx()
-    printCanvas(canvas, name+"_logX", formats, directory) 
+    Tleft.Draw() 
+    Tright.Draw() 
+    
+    pads["base"].cd()
+
+    if ratio is not None:
+        pads["ratio"] = ROOT.TPad("ratio", "", 0, 0, 1, 0.2)
+        pads["ratio"].Draw()
+        pads["ratio"].cd()
+        pads["ratio"].SetGrid()
+        
+        tmp_h = ROOT.TH1F(name + "tmp_ratio", "", 1, mg.GetXaxis().GetXmin(), mg.GetXaxis().GetXmax())
+        tmp_h.GetYaxis().SetTitleSize(0.2)
+        tmp_h.GetYaxis().SetTitleOffset(0.2)
+        tmp_h.GetYaxis().CenterTitle()
+        tmp_h.GetYaxis().SetNdivisions(6, 2, 0)
+        tmp_h.GetYaxis().SetLabelSize(0.15)
+        tmp_h.GetXaxis().SetNdivisions(5, 5, 0, 0)
+        tmp_h.GetXaxis().SetLabelSize(0.0)
+        tmp_h.SetDirectory(0)
+        
+        ratio = createRatioFromGraph(graphs[ratio[0]], graphs[ratio[1]])
+        min, max = getGraphMinMax(ratio)
+        tmp_h.GetYaxis().SetRangeUser(0.9*min, 1.1*max)
+        tmp_h.Draw()
+        ratio.Draw(style)
+        
+        unity = ROOT.TF1("unity", "1", -1000, 1000)
+        unity.SetLineColor(8)
+        unity.SetLineWidth(1)
+        unity.SetLineStyle(1)
+        unity.Draw("same")
+
+    printCanvas(pads["canvas"], name, formats, dir) 
+
+    if doLogX:
+        if logRange:
+            mg.GetXaxis().SetRangeUser(logRange[0][0], logRange[0][1])
+            mg.GetYaxis().SetRangeUser(logRange[1][0], logRange[1][1])
+        pads["hist"].SetLogx()
+        printCanvas(pads["canvas"], name + "_logX", formats, dir) 
 
 
 def gStyle():


### PR DESCRIPTION
- Add script finding bin limits to flatten a distribution
- A few fixes to the tool used to quickly draw not too ugly TGraphs, add possibility to have a ratio plot
- New function in HistogramTools: retrieve all TH1 objects from a file, whose name matches a regex