### PR TITLE
Possibily to weight data; arguments to sample weights

### DIFF
--- a/Factories/README.md
+++ b/Factories/README.md
@@ -94,7 +94,7 @@ The following variables can be defined, and are not mandatory:
  - `code_after_loop`: (string) Code inserted after the loop over the events.
 Specified paths cans be absolute, relative from the current directory, or relative from the directory where the python script is stored.
 
-In case a single sample is to be reweighted to produce different outputs, another dictionary can be defined: `sample_weights`. Each key is the name of the resulting reweighting, and the corresponding entry gives the weight to be used (any valid C++ code).
+In case a single sample is to be reweighted to produce different outputs, another dictionary can be defined: `sample_weights`. Each key is the name of the resulting reweighting, and the corresponding entry gives the weight to be used (any valid C++ code). Some arguments can be passed from the dataset JSONs (see below) to the code evaluated here, as a (const) vector of strings called `sample_weight_args`.
 
 #### Generating histograms
 
@@ -106,6 +106,7 @@ An example of a valid python script is given in `test/plots.py`. The script need
  - `binning` (mandatory): String defining the binning to be used for each dimension. Each dimension can use fixed or variable-sized binning, for instance: `(10, 0, 5, 3, { 0, 2, 2.5, 3 })` defines 10 fixed-sized bins from `x=0` to `x=5` and 3 variable-size bins over `y`, where the bin edges are defined in the array `{}`.
  - `folder` (optional): Folder inside the output file where the histogram is to be saved.
  - `normalize-to`: Name of an alternate normalisation constant to be used (given in the input JSON)
+ - `allow-weighted-data`: (optional, default to False) Boolean; if true, do NOT force weights to 1 for data.
 
 
 #### Generating a tree
@@ -137,6 +138,7 @@ The entries in the JSON file passed to either `plotter.exe` or `skimmer.exe` can
  - `event-weight-sum` (default to `1`): stored as TParameter in the output file. In HistFactory, histograms are scaled by `cross-section/event-weight-sum`
  - `extras-event-weight-sum` (optional): Dictionary of extra event weight sums to use (for systematics, for instance). By default the only key is `"nominal"`, with value `event-weight-sum`
  - `sample-weight` (optional): Name of the special per-event sample weight to be used (see above, Python file format)
+ - `sample-weight-args` (optional): Arguments made available to the function returning the sample weight. Should be a list of strings.
  - `files`: List of files as input, or:
  - `path`: Take all `.root` files in this directory
  - `event-start` (default `0`): first event to be read

--- a/Factories/include/Factory.h
+++ b/Factories/include/Factory.h
@@ -36,6 +36,15 @@
     var = PyString_AsString(item); \
 }
 
+#define GET_BOOL(var, obj) if (PyDict_Contains(value, obj) == 1) { \
+    PyObject* item = PyDict_GetItem(value, obj); \
+    if (! PyBool_Check(item)) {\
+        std::cerr << "Error: the '" << PyString_AsString(obj) << "' value must be a boolean" << std::endl; \
+        return false; \
+    } \
+    var = PyObject_IsTrue(item); \
+}
+
 struct BuildCustomization {
     std::set<boost::filesystem::path> include_directories;
     std::set<std::string> headers;

--- a/Factories/include/HistFactory.h
+++ b/Factories/include/HistFactory.h
@@ -18,6 +18,8 @@ struct Plot {
     std::string x_axis;
     std::string y_axis;
     std::string z_axis;
+
+    bool allow_weight_on_data;
 };
 
 class HistFactory: public Factory {

--- a/Factories/src/HistFactory.cc
+++ b/Factories/src/HistFactory.cc
@@ -14,6 +14,8 @@ bool plot_from_PyObject(PyObject* value, Plot& plot) {
     static PyObject* PY_X_AXIS = PyString_FromString("x-axis");
     static PyObject* PY_Y_AXIS = PyString_FromString("y-axis");
     static PyObject* PY_Z_AXIS = PyString_FromString("z-axis");
+    
+    static PyObject* PY_WEIGHT_DATA = PyString_FromString("allow-weighted-data");
 
     if (! PyDict_Check(value)) {
         std::cerr << "Error: plots dictionnary value must be a dictionnary" << std::endl;
@@ -39,6 +41,9 @@ bool plot_from_PyObject(PyObject* value, Plot& plot) {
     GET(plot.x_axis, PY_X_AXIS);
     GET(plot.y_axis, PY_Y_AXIS);
     GET(plot.z_axis, PY_Z_AXIS);
+
+    plot.allow_weight_on_data = false;
+    GET_BOOL(plot.allow_weight_on_data, PY_WEIGHT_DATA);
 
     return true;
 }
@@ -166,7 +171,10 @@ bool HistFactory::create_templates(std::set<std::string>& identifiers, std::stri
         plot.SetValue("VAR", variable_string);
         plot.SetValue("HIST", p.unique_name);
 
-        ctemplate::ExpandTemplate(get_template("Plot"), ctemplate::DO_NOT_STRIP, &plot, &inLoop);
+        if (p.allow_weight_on_data)
+            ctemplate::ExpandTemplate(get_template("PlotNoCheckData"), ctemplate::DO_NOT_STRIP, &plot, &inLoop);
+        else
+            ctemplate::ExpandTemplate(get_template("Plot"), ctemplate::DO_NOT_STRIP, &plot, &inLoop);
     }
 
     std::cout << "Done." << std::endl;

--- a/Factories/templates/Main.cc.tpl
+++ b/Factories/templates/Main.cc.tpl
@@ -27,7 +27,7 @@
 
 volatile bool MUST_STOP = false;
 
-double {{CLASS_NAME}}::getSampleWeight() {
+double {{CLASS_NAME}}::getSampleWeight(const std::vector<std::string>& sample_weight_args) {
 {{SAMPLE_WEIGHT_IMPL}}
 }
 
@@ -65,7 +65,7 @@ void {{CLASS_NAME}}::work(const std::string& output_file) {
 
         double __sample_weight = 1.;
         if (!m_dataset.is_data)
-            __sample_weight = getSampleWeight();
+            __sample_weight = getSampleWeight(m_dataset.sample_weight_args);
 
         bool __cut = false;
         double __weight = 0;
@@ -155,6 +155,11 @@ bool parse_datasets(const std::string& json_file, std::vector<Dataset>& datasets
         // Sample weights
         if (sample.isMember("sample-weight")) {
             dataset.sample_weight_key = sample["sample-weight"].asString();
+            if (sample.isMember("sample-weight-args")) {
+                Json::Value args = sample["sample-weight-args"];
+                for (auto it: args)
+                    dataset.sample_weight_args.push_back(it.asString());
+            }
         } else {
             dataset.sample_weight_key = "";
         }
@@ -163,7 +168,7 @@ bool parse_datasets(const std::string& json_file, std::vector<Dataset>& datasets
         if (sample.isMember("files")) {
             Json::Value files = sample["files"];
 
-            for(auto it = files.begin(); it != files.end(); ++it) {
+            for (auto it = files.begin(); it != files.end(); ++it) {
                 dataset.files.push_back((*it).asString());
             }
         } else if (sample.isMember("path")) {

--- a/Factories/templates/Main.h.tpl
+++ b/Factories/templates/Main.h.tpl
@@ -80,6 +80,7 @@ struct Dataset {
     std::map<std::string, double> extras_event_weight_sum;
     bool is_data;
     std::string sample_weight_key;
+    std::vector<std::string> sample_weight_args;
     uint64_t event_start = 0;
     uint64_t event_end;
     bool event_end_filled = false;
@@ -125,7 +126,7 @@ class {{CLASS_NAME}} {
             h->Fill(value_x, value_y, value_z, weight);
         }
 
-        double getSampleWeight();
+        double getSampleWeight(const std::vector<std::string>& sample_weight_args);
 
         Dataset m_dataset;
         ROOT::TreeWrapper tree;

--- a/Factories/templates/PlotNoCheckData.tpl
+++ b/Factories/templates/PlotNoCheckData.tpl
@@ -1,0 +1,6 @@
+        __cut = ({{CUT}});
+        if (__cut) {
+            __weight = ({{WEIGHT}}) * __sample_weight;
+            fill({{HIST}}.get(), {{VAR}}, __weight);
+        }
+


### PR DESCRIPTION
Add new, non-mandatory field in the plots entries for HistFactory: `allow-weighted-data`. If set to `True` for a plot, the weight applied to that plot will not be forced to 1 when running on data.

Given the discussion in #136 and @blinkseb's input, this seems the most straightforward solution if one wants to avoid generating two separate plotters to derive data-driven estimates.

Also, allow passing arguments to the functions returning so-called sample weights. Those arguments can be passed as a list of strings in the dataset JSON (new entry: `sample-weight-args`), and will be available inside the function returning the sample weight as a vector of strings called `sample_weight_args`

Note: based on #135 