### PR TITLE
[Factories] Turn on compiler optimizations expect for main file

### DIFF
--- a/Factories/templates/CMakeLists.txt.tpl
+++ b/Factories/templates/CMakeLists.txt.tpl
@@ -11,7 +11,7 @@ include(CMSSW)
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX0X)
 if(COMPILER_SUPPORTS_CXX0X)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -g -O2")
 else()
     message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
@@ -69,6 +69,9 @@ set(SOURCES
         common/src/scale_factors.cpp
         {{USER_SOURCES}}
     )
+
+# Disable optimization for the main source file only: compile time explode if we enable compile optimizations
+set_source_files_properties({{NAME}}.cc PROPERTIES COMPILE_FLAGS -O0)
 
 if(IN_CMSSW)
     include(CP3Dictionaries)


### PR DESCRIPTION
Even with -O1, the compilation time when there's more than ~100
histograms gets out of control (> 20h). Instead of penalizing every source file, turn on optimizations for everything, and turn off only for the main file.