### PR TITLE
Link factories with GSL

### DIFF
--- a/Factories/templates/CMakeLists.txt.tpl
+++ b/Factories/templates/CMakeLists.txt.tpl
@@ -34,6 +34,13 @@ if(NOT IN_CMSSW)
     list(APPEND CMAKE_INCLUDE_PATH "${PYTHON_PREFIX}/include")
 endif()
 
+# Find GSL
+if(IN_CMSSW)
+    execute_process(COMMAND scram tool tag gsl GSL_BASE OUTPUT_VARIABLE GSL_ROOT_DIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+find_package(GSL REQUIRED)
+include_directories(SYSTEM ${GSL_INCLUDE_DIRS})
+
 set(Boost_NO_BOOST_CMAKE ON)
 find_package(Boost REQUIRED COMPONENTS python)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
@@ -103,6 +110,7 @@ endif()
 
 target_link_libraries(generated ${PYTHON_LIBRARY})
 target_link_libraries(generated ${Boost_PYTHON_LIBRARY})
+target_link_libraries(generated ${GSL_LIBRARIES})
 
 # Find libraries requested by the user, if any
 {{#HAS_LIBRARY_DIRECTORIES}}

--- a/toolBox/drawCanvas.py
+++ b/toolBox/drawCanvas.py
@@ -110,7 +110,18 @@ def drawTGraph(graphs, name, xLabel="", yLabel="", legend=None, leftText="", rig
     Tright.SetTextFont(font) 
 
     mg = ROOT.TMultiGraph()
-    colors = [ ROOT.kRed, ROOT.kBlue, ROOT.kMagenta, ROOT.kCyan+1, ROOT.kGreen+2, ROOT.kOrange+1 ]
+    colors = [ ROOT.TColor.GetColor(hex) for hex in [
+            "#1f77b4",
+            "#ff7f0e",
+            "#2ca02c",
+            "#d62728",
+            "#9467bd",
+            "#8c564b",
+            "#e377c2",
+            "#7f7f7f",
+            "#bcbd22",
+            "#17becf",
+        ] ]
     markers = [20, 21, 22, 23, 29, 33, 34]
     
     for i, graph in enumerate(graphs):


### PR DESCRIPTION
Link produced factories with GSL by default. It's installed on most systems and present in CMSSW.

Completely different but not worth a separate PR: the default colors for the "drawTGraph" utility now come from https://github.com/vega/vega/wiki/Scales#scale-range-literals