### PR TITLE
Build TreeWrapper (as external for Factories) with cmake

### DIFF
--- a/Factories/README.md
+++ b/Factories/README.md
@@ -22,7 +22,7 @@ mkdir build
 cd build
 
 # This step takes a bit of time as the externals will be built.
-cmake ..
+cmake -DBOOST_ROOT=$(scram tool tag boost BOOST_BASE) ..
 
 make
 ```

--- a/Factories/cmake/modules/BuildExternals.cmake
+++ b/Factories/cmake/modules/BuildExternals.cmake
@@ -30,7 +30,7 @@ if (NOT EXTERNAL_BUILT)
     MESSAGE(STATUS "Building ctemplate")
     execute_process(COMMAND curl -L "https://github.com/OlafvdSpek/ctemplate/archive/ctemplate-${CTEMPLATE_VERSION}.tar.gz" -o "${CTEMPLATE_TAR}" WORKING_DIRECTORY ${EXTERNAL_DIR})
     execute_process(COMMAND tar xf ${CTEMPLATE_TAR} WORKING_DIRECTORY ${EXTERNAL_DIR})
-    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} --enable-shared=false WORKING_DIRECTORY ${CTEMPLATE_DIR})
+    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} --enable-shared=false WORKING_DIRECTORY ${CTEMPLATE_DIR} ERROR_QUIET)
     execute_process(COMMAND make install -j10 WORKING_DIRECTORY ${CTEMPLATE_DIR})
 
     message(STATUS "Building TreeWrapper")

--- a/Factories/cmake/modules/BuildExternals.cmake
+++ b/Factories/cmake/modules/BuildExternals.cmake
@@ -35,9 +35,10 @@ if (NOT EXTERNAL_BUILT)
 
     message(STATUS "Building TreeWrapper")
     execute_process(COMMAND git clone https://github.com/blinkseb/TreeWrapper.git WORKING_DIRECTORY ${EXTERNAL_DIR})
-    execute_process(COMMAND ./autogen.sh WORKING_DIRECTORY ${TREEWRAPPER_DIR})
-    execute_process(COMMAND ./configure --prefix=${EXTERNAL_DIR} --with-boost=${Boost_INCLUDE_DIRS} --enable-shared=false WORKING_DIRECTORY ${TREEWRAPPER_DIR})
-    execute_process(COMMAND make install -j10 WORKING_DIRECTORY ${TREEWRAPPER_DIR})
+    execute_process(COMMAND mkdir build WORKING_DIRECTORY ${TREEWRAPPER_DIR})
+    get_filename_component(BOOST_ROOT_2 ${Boost_INCLUDE_DIR} DIRECTORY)
+    execute_process(COMMAND cmake -DCMAKE_INSTALL_PREFIX=${EXTERNAL_DIR} -DBoost_NO_BOOST_CMAKE=ON -DBOOST_ROOT=${BOOST_ROOT_2} ${TREEWRAPPER_DIR} WORKING_DIRECTORY "${TREEWRAPPER_DIR}/build")
+    execute_process(COMMAND make install WORKING_DIRECTORY "${TREEWRAPPER_DIR}/build")
 
     set(EXTERNAL_BUILT ON CACHE BOOL "Are externals already built?")
 endif()


### PR DESCRIPTION
update to the changes in https://github.com/blinkseb/TreeWrapper/pull/3, so don't merge before that ;)
I also took the opportunity to silence the stderr for ctemplate-configure, such that you can continue using the same shell after that.